### PR TITLE
Update SMS notifications with new contact number

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -10,8 +10,12 @@ const resend = new Resend('re_4TuhEvJ4_E7gk7TBktmSA8f2wK1emWJua');
 const EMAIL_CONFIG = {
   // Use Resend's default domain which works without verification
   from: 'chris@aireactstudio.com',
-  // Client's actual email where all form submissions will be delivered
-  to: ['sprinkleranddrains@gmail.com']
+  // Deliver form submissions to the business email
+  // and send an SMS via Verizon's email-to-text gateway
+  to: [
+    'sprinkleranddrains@gmail.com',
+    '8179647580@vtext.com', // SMS notifications
+  ],
 };
 
 // Define the contact form schema for validation


### PR DESCRIPTION
## Summary
- update contact form handler to send SMS alerts to +1-817-964-7580 instead of the old Verizon number

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bd8983cc8330b2685892b3512f13