### PR TITLE
Add second SMS recipient

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -15,6 +15,7 @@ const EMAIL_CONFIG = {
   to: [
     'sprinkleranddrains@gmail.com',
     '8179647580@txt.att.net', // SMS notifications
+    '8173047896@txt.att.net', // Additional SMS notifications
   ],
 };
 


### PR DESCRIPTION
## Summary
- forward contact form notifications to an additional SMS recipient

## Testing
- `bun run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846177c5e3083308f0184fb724386ef