### PR TITLE
Fix hero contact link

### DIFF
--- a/src/components/location-homepages/LocationHeroSection.tsx
+++ b/src/components/location-homepages/LocationHeroSection.tsx
@@ -120,7 +120,7 @@ export default function LocationHeroSection({
                 className="bg-white/10 backdrop-blur-md border-white/20 text-white hover:bg-white/20 px-8 py-4 rounded-xl font-semibold text-lg shadow-2xl transition-all duration-200"
                 asChild
               >
-                <a href="#contact">
+                <a href="/contact">
                   Get Free Estimate
                 </a>
               </Button>


### PR DESCRIPTION
## Summary
- update free estimate button to link to `/contact`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863eacd6fb48330bd1aff56d12e9978