### PR TITLE
Fix hero not covering iOS status bar

### DIFF
--- a/src/app/head.tsx
+++ b/src/app/head.tsx
@@ -16,6 +16,13 @@ export default function Head() {
         type="image/webp" 
         fetchPriority="high"
       />
+      {/* Ensure mobile devices use the full screen including the notch area */}
+      <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1, viewport-fit=cover"
+      />
+      {/* Match the browser chrome color with the hero background */}
+      <meta name="theme-color" content="#1A3E68" />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- ensure viewport covers the notch on iOS
- match browser chrome with hero background color

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_686d17d7d808833098e6bec46cf3614c