### PR TITLE
Fix hero section to respect iOS safe area

### DIFF
--- a/src/app/head.tsx
+++ b/src/app/head.tsx
@@ -23,6 +23,9 @@ export default function Head() {
       />
       {/* Match the browser chrome color with the hero background */}
       <meta name="theme-color" content="#1A3E68" />
+      {/* Allow content to extend into the iOS status bar area */}
+      <meta name="apple-mobile-web-app-capable" content="yes" />
+      <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     </>
   );
 }

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -34,7 +34,13 @@ const HeroSection: React.FC<HeroSectionProps> = ({
   cta,
 }) => {
   return (
-    <section className="relative min-h-[90vh] flex items-center justify-center overflow-hidden">
+    <section
+      className="relative min-h-[90vh] flex items-center justify-center overflow-hidden"
+      style={{
+        paddingTop: 'env(safe-area-inset-top)',
+        marginTop: 'calc(env(safe-area-inset-top) * -1)'
+      }}
+    >
       {/* Background Image with Overlay - Simple for reliable performance */}
       <div className="absolute inset-0 overflow-hidden z-0">
         <Image 

--- a/src/components/location-homepages/LocationHeroSection.tsx
+++ b/src/components/location-homepages/LocationHeroSection.tsx
@@ -46,7 +46,13 @@ export default function LocationHeroSection({
   const phoneNumber = "(817) 304-7896";
 
   return (
-    <section className="relative overflow-hidden min-h-[80vh] w-full">
+    <section
+      className="relative overflow-hidden min-h-[80vh] w-full"
+      style={{
+        paddingTop: 'env(safe-area-inset-top)',
+        marginTop: 'calc(env(safe-area-inset-top) * -1)'
+      }}
+    >
       {/* Background Image with Enhanced Overlay */}
       <div className="absolute inset-0 z-0 w-full h-full">
         <div className="absolute inset-0 w-full h-full">

--- a/src/components/service-page/ServiceHero.tsx
+++ b/src/components/service-page/ServiceHero.tsx
@@ -9,7 +9,13 @@ interface ServiceHeroProps {
 
 export default function ServiceHero({ serviceContent, location }: ServiceHeroProps) {
   return (
-    <div className="relative w-full h-[75vh] min-h-[500px]">
+    <div
+      className="relative w-full h-[75vh] min-h-[500px]"
+      style={{
+        paddingTop: 'env(safe-area-inset-top)',
+        marginTop: 'calc(env(safe-area-inset-top) * -1)'
+      }}
+    >
       <Image
         src="/assets/images/optimized/hero-background.webp"
         alt={serviceContent.title}

--- a/src/components/templates/ServicePageLayout.tsx
+++ b/src/components/templates/ServicePageLayout.tsx
@@ -155,7 +155,13 @@ export default function ServicePageLayout({
   return (
     <>
       {/* Hero/Header */}
-      <div className="relative h-[75vh] min-h-[500px]">
+      <div
+        className="relative h-[75vh] min-h-[500px]"
+        style={{
+          paddingTop: 'env(safe-area-inset-top)',
+          marginTop: 'calc(env(safe-area-inset-top) * -1)'
+        }}
+      >
         <Image 
           src={image} 
           alt={title} 


### PR DESCRIPTION
## Summary
- allow pages to extend into the iOS status bar
- adjust hero components so backgrounds reach the very top of the screen

## Testing
- `npm install`
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_686d1ff5b33c8330a1bd09d6e143382e