### PR TITLE
Add Landscaping Installation service page and navigation links

### DIFF
--- a/src/app/services/landscaping-installation/page.tsx
+++ b/src/app/services/landscaping-installation/page.tsx
@@ -1,0 +1,93 @@
+import type { Metadata } from 'next';
+import { Trees } from 'lucide-react';
+import ServicePageLayout from '@/components/templates/ServicePageLayout';
+import CTA from '@/components/CTA';
+
+export const metadata: Metadata = {
+  title: 'Landscaping Installation | Texas Best Sprinklers',
+  description:
+    'Professional landscaping installation services in Fort Worth and surrounding North Texas cities, including hardscape construction, retaining walls, sod installation, softscape design, and water features.',
+  openGraph: {
+    title: 'Landscaping Installation | Texas Best Sprinklers',
+    description:
+      'Upgrade your outdoor space with complete landscaping installation services built for North Texas homes.',
+    url: 'https://sprinkleranddrains.com/services/landscaping-installation',
+    type: 'website',
+  },
+};
+
+const landscapingServices = [
+  {
+    title: 'Hardscape Construction',
+    description:
+      'Build structure and function into your yard with patios, walkways, concrete pads, and decorative borders designed to hold up in North Texas weather.',
+  },
+  {
+    title: 'Retaining Walls',
+    description:
+      'Control elevation changes, reduce erosion, and create cleaner transitions in sloped areas with professionally installed retaining walls.',
+  },
+  {
+    title: 'Sod Installation',
+    description:
+      'Get an instantly greener lawn with professionally installed sod, proper base prep, and watering guidance for healthy root establishment.',
+  },
+  {
+    title: 'Softscape Design',
+    description:
+      'Enhance curb appeal with thoughtfully planned plant beds, shrubs, trees, mulch, and seasonal color selected for your property and sun exposure.',
+  },
+  {
+    title: 'Water Features',
+    description:
+      'Add movement and ambiance to your landscape with custom water features that complement your layout and outdoor living spaces.',
+  },
+];
+
+export default function LandscapingInstallationPage() {
+  const serviceProps = {
+    serviceType: 'landscaping-installation',
+    title: 'Landscaping Installation',
+    description:
+      'Complete landscape installation services tailored to your property goals, from structural hardscape elements to living plant design and finishing features.',
+    icon: <Trees size={32} className="text-white" />,
+    image: '/assets/images/optimized/hero-background.webp',
+    features: landscapingServices.map((service) => service.title),
+  };
+
+  return (
+    <ServicePageLayout {...serviceProps}>
+      <section className="space-y-6">
+        <h2 className="text-2xl md:text-3xl font-bold text-irrigation-blue">
+          Our Landscaping Installation Services
+        </h2>
+        <p className="text-lg leading-relaxed text-gray-800">
+          Texas Best Sprinklers provides full-service landscaping installation for homeowners across the Fort Worth area. Whether you are refreshing one section of your yard or building a complete outdoor environment, we install every layer with long-term performance in mind.
+        </p>
+      </section>
+
+      <section className="mt-10 grid grid-cols-1 gap-6 md:grid-cols-2">
+        {landscapingServices.map((service) => (
+          <article key={service.title} className="rounded-lg bg-white p-6 shadow-md">
+            <h3 className="text-xl font-bold text-irrigation-darkBlue">{service.title}</h3>
+            <p className="mt-3 text-gray-800">{service.description}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="mt-12 rounded-xl border border-irrigation-blue/20 bg-irrigation-gray p-6 md:p-8">
+        <h2 className="text-2xl font-bold text-irrigation-blue">Built to Work with Irrigation & Drainage</h2>
+        <p className="mt-4 text-gray-800 leading-relaxed">
+          Because irrigation and drainage are our core specialties, we design landscaping installs so your lawn, planting zones, hardscape areas, and water flow all work together. That helps prevent costly rework and gives you a cleaner, longer-lasting result.
+        </p>
+      </section>
+
+      <CTA
+        title="Ready to Plan Your Landscaping Installation?"
+        subtitle="Tell us what you want to build, and we will put together a landscaping plan tailored to your home and budget."
+        buttonText="Request a Landscaping Quote"
+        buttonLink="/contact"
+      />
+    </ServicePageLayout>
+  );
+}

--- a/src/app/services/page.tsx
+++ b/src/app/services/page.tsx
@@ -90,6 +90,13 @@ export default function Services() {
               icon={<Droplet size={32} />}
               id="sod-and-land-leveling"
             />
+
+            <ServiceCard
+              title="Landscaping Installation"
+              description="Complete landscaping installations including hardscape construction, retaining walls, sod installation, softscape design, and custom water features."
+              icon={<TreeDeciduous size={32} />}
+              id="landscaping-installation"
+            />
             
             <ServiceCard 
               title="Outdoor Lighting"

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -99,6 +99,7 @@ const AppHeader = () => {
         { name: 'Sprinkler System Reroutes', path: '/services/sprinkler-system-reroutes' },
         { name: 'Drip Irrigation', path: '/services/drip-irrigation' },
         { name: 'SOD Installation & Land Leveling', path: '/services/sod-and-land-leveling' },
+        { name: 'Landscaping Installation', path: '/services/landscaping-installation' },
         { name: 'Hardscaping', path: '/services/hardscaping' },
         { name: 'Sprinkler Blow Out', path: '/services/sprinkler-blow-out' },
         { name: 'Sprinkler Winterization', path: '/services/sprinkler-winterization' },

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -73,6 +73,7 @@ const Footer = () => {
                 'Outdoor Lighting',
                 'System Maintenance',
                 'Sprinkler Repair',
+                'Landscaping Installation',
                 'Commercial Solutions',
               ].map((service) => {
                 const routeMap: Record<string, string> = {
@@ -81,6 +82,7 @@ const Footer = () => {
                   'Outdoor Lighting': '/services/lighting',
                   'System Maintenance': '/services/maintenance',
                   'Sprinkler Repair': '/services/irrigation-repair',
+                  'Landscaping Installation': '/services/landscaping-installation',
                   'Commercial Solutions': '/services',
                 };
                 const href = routeMap[service] || '/services';

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -127,6 +127,12 @@ const Header = () => {
                   >
                     SOD Installation & Land Leveling
                   </Link>
+                  <Link 
+                    href="/services/landscaping-installation"
+                    className={`block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 ${pathname?.startsWith('/services/landscaping-installation') ? 'bg-gray-50 text-irrigation-blue font-medium' : ''}`}
+                  >
+                    Landscaping Installation
+                  </Link>
                 </div>
               </div>
             </li>
@@ -304,6 +310,17 @@ const Header = () => {
                   onClick={() => setIsMobileMenuOpen(false)}
                 >
                   SOD Installation & Land Leveling
+                </Link>
+                <Link 
+                  href="/services/landscaping-installation" 
+                  className={`block text-sm ${
+                    pathname?.startsWith('/services/landscaping-installation') 
+                    ? 'text-irrigation-blue font-medium' 
+                    : 'text-gray-600'
+                  }`}
+                  onClick={() => setIsMobileMenuOpen(false)}
+                >
+                  Landscaping Installation
                 </Link>
               </div>
             </li>


### PR DESCRIPTION
### Motivation
- Add a dedicated Landscaping Installation service page so the site can present and market full landscaping installs as an offering. 
- Make the new service discoverable from existing navigation and footer so users can find it from the main site menus and services listing. 
- Ensure the page explicitly covers the requested services: `Hardscape Construction`, `Retaining Walls`, `Sod Installation`, `Softscape Design`, and `Water Features`.

### Description
- Added a new service page at `src/app/services/landscaping-installation/page.tsx` with metadata, a services list, descriptive sections, and a CTA. 
- Added a card for the new service to the services overview grid in `src/app/services/page.tsx` so it appears on the `/services` listing. 
- Added the `Landscaping Installation` menu entry to the primary navigation used by `AppHeader` in `src/components/AppHeader.tsx` and to the legacy `Header` dropdown and mobile submenu in `src/components/Header.tsx`. 
- Added the service to the footer services list and route map in `src/components/Footer.tsx` and used `Trees`/`TreeDeciduous` icons for the new UI elements.

### Testing
- Ran `npm run lint`, but the Next.js ESLint setup opened an interactive prompt in this environment so automated linting could not complete. 
- Performed code-level verification by searching the codebase to confirm links and references were added to `AppHeader`, `Header`, `Footer`, and the services listing (no runtime tests were executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd7cd117908332866632fc5b15bc84)