### PR TITLE
Move Landscaping & Hardscaping to top-level mobile navigation

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -153,6 +153,25 @@ const AppHeader = () => {
     }
   ];
 
+  const mobileMenuItems: NavItem[] = (() => {
+    const sprinklerMenu = menuItems.find((item) => item.name === 'Sprinklers & Irrigation');
+    const filteredSprinklerSubmenu = (sprinklerMenu?.submenu ?? []).filter(
+      (subitem) => subitem.name !== 'Landscaping Installation' && subitem.name !== 'Hardscaping'
+    );
+
+    return menuItems.flatMap((item) => {
+      if (item.name !== 'Sprinklers & Irrigation') {
+        return [item];
+      }
+
+      return [
+        { ...item, submenu: filteredSprinklerSubmenu },
+        { name: 'Landscaping Installation', path: '/services/landscaping-installation' },
+        { name: 'Hardscaping', path: '/services/hardscaping' },
+      ];
+    });
+  })();
+
   // Build dynamic locations list for mega menu
   const allLocations = LOCATIONS.map(slug => {
     const info = getLocationData(slug);
@@ -328,7 +347,7 @@ const AppHeader = () => {
                 {/* Menu Items */}
                 <div className="flex-grow overflow-y-auto py-4">
                   <ul className="space-y-1 px-2">
-                    {menuItems.map((item) => (
+                    {mobileMenuItems.map((item) => (
                       <li key={item.name}>
                          {item.submenu ? (
                           <>


### PR DESCRIPTION
### Motivation
- Improve mobile navigation discoverability by extracting `Landscaping Installation` and `Hardscaping` out of the Sprinklers & Irrigation submenu and surfacing them as their own top-level items on mobile while keeping desktop behavior unchanged.

### Description
- Added a computed `mobileMenuItems` list in `src/components/AppHeader.tsx` that derives from the shared `menuItems` but removes `Landscaping Installation` and `Hardscaping` from the Sprinklers & Irrigation submenu and inserts them as separate top-level entries.
- Replaced the mobile menu renderer to iterate over `mobileMenuItems` instead of `menuItems` so the change only affects the mobile panel.
- No desktop menu structure or desktop dropdown behavior was modified.

### Testing
- Attempted to run `npm run lint -- --file src/components/AppHeader.tsx`, but `next lint` prompted for initial ESLint setup interactively so lint could not run non-interactively in this environment.
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c6be8f208332888fcfe74c665e88)