### PR TITLE
Add Ridgewood neighborhood page for Keller

### DIFF
--- a/src/app/keller/ridgewood/page.tsx
+++ b/src/app/keller/ridgewood/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import RidgewoodPage from '@/components/neighborhoods/RidgewoodPage';
+
+export const metadata: Metadata = {
+  title: 'Ridgewood Sprinkler Services | Keller, TX | Texas Best Sprinklers',
+  description:
+    'Sprinkler repair, irrigation tune-ups, and drainage solutions for Ridgewood homes in Keller, TX. Licensed local service with free estimates.',
+  alternates: {
+    canonical: 'https://sprinkleranddrains.com/keller/ridgewood'
+  }
+};
+
+export default function RidgewoodKellerPage() {
+  return <RidgewoodPage />;
+}

--- a/src/components/neighborhoods/RidgewoodPage.tsx
+++ b/src/components/neighborhoods/RidgewoodPage.tsx
@@ -1,0 +1,230 @@
+import React from 'react';
+import NeighborhoodPageTemplate from '@/components/templates/NeighborhoodPageTemplate';
+
+export default function RidgewoodPage() {
+  return (
+    <NeighborhoodPageTemplate
+      cityName="Keller"
+      citySlug="keller"
+      neighborhoodName="Ridgewood"
+      canonicalUrl="https://sprinkleranddrains.com/keller/ridgewood"
+      pageTitle="Ridgewood Sprinkler Services in Keller, TX"
+      metaDescription="Sprinkler repair, irrigation tune-ups, and drainage services for Ridgewood homes in Keller, TX with licensed local technicians."
+      heroTitle="Ridgewood Sprinkler Repair & Irrigation Services in Keller"
+      heroDescription="Licensed sprinkler, irrigation, and drainage help for Ridgewood homeowners who want dependable coverage, cleaner runoff control, and efficient watering through North Texas heat."
+      introHeading="Practical Irrigation Support for Ridgewood Homes"
+      intro="Ridgewood properties in Keller often need irrigation systems that can handle established lawns, mature landscape beds, shifting clay soil, and quick weather changes. Texas Best Sprinklers, Drainage and Lighting helps homeowners diagnose sprinkler problems, correct uneven coverage, improve controller programming, and plan drainage improvements that protect curb appeal without wasting water. Our team focuses on clear recommendations, clean work areas, and system adjustments that make sense for the way Ridgewood yards are actually used."
+      highlights={[
+        'Licensed irrigator service for Keller homeowners, including sprinkler repair, irrigation repair, and drainage planning.',
+        'Zone-by-zone inspections that look for broken heads, valve issues, wiring faults, pressure problems, and overspray.',
+        'Water-conscious scheduling recommendations for North Texas clay soil, summer heat, and local watering expectations.',
+        'Repair and upgrade options for established lawns, planting beds, side yards, and areas with recurring runoff.'
+      ]}
+      serviceFocus={[
+        {
+          title: 'Sprinkler Diagnostics',
+          description:
+            'We trace coverage gaps, stuck valves, leaking heads, low-pressure zones, and controller issues so repairs solve the real cause instead of only the most visible symptom.'
+        },
+        {
+          title: 'Coverage and Efficiency Improvements',
+          description:
+            'Nozzle changes, head adjustments, pressure checks, and smart scheduling help Ridgewood lawns receive more even watering with less overspray onto sidewalks and driveways.'
+        },
+        {
+          title: 'Drainage Planning',
+          description:
+            'For low spots, side-yard pooling, and runoff near patios or beds, we recommend practical drainage improvements based on grade, soil, and where water naturally collects.'
+        }
+      ]}
+      localTips={[
+        'Use shorter cycle-and-soak watering windows when Keller clay soil starts shedding water before it can soak into the root zone.',
+        'Check spray patterns after mowing or edging because tilted heads can quickly create dry strips along sidewalks and driveways.',
+        'Adjust shaded zones separately from full-sun turf so mature trees and protected beds are not watered on the same schedule as hot open areas.',
+        'Schedule seasonal inspections before peak summer heat to catch small leaks, clogged nozzles, and controller programming issues early.'
+      ]}
+      reviews={[
+        {
+          reviewer: 'Ridgewood homeowner in Keller',
+          date: 'March 2026',
+          quote:
+            'They walked every zone, explained exactly why two areas were staying dry, and made the repairs without leaving a mess in the yard.'
+        },
+        {
+          reviewer: 'Keller resident near Ridgewood',
+          date: 'February 2026',
+          quote:
+            'The team adjusted our controller and fixed several heads that were spraying the driveway. The system is much more consistent now.'
+        },
+        {
+          reviewer: 'Homeowner in Ridgewood',
+          date: 'January 2026',
+          quote:
+            'Clear pricing, fast diagnostics, and helpful advice on how to avoid runoff during the summer. We would call them again.'
+        }
+      ]}
+      considerations={[
+        {
+          title: 'Established Keller Landscapes',
+          description:
+            'Ridgewood homes may have mature turf, older beds, and irrigation layouts that have been changed over time. A zone-by-zone check helps confirm each area is still matched to current landscaping.'
+        },
+        {
+          title: 'North Texas Clay Soil',
+          description:
+            'Clay soil can expand, contract, and shed water during long cycles. Cycle-and-soak programming and drainage review help reduce puddling and improve root-zone absorption.'
+        },
+        {
+          title: 'Side-Yard and Foundation Runoff',
+          description:
+            'Narrow side yards and grade transitions can move water toward hardscapes or foundations. Drainage solutions should be planned around the actual flow path, not just the lowest visible spot.'
+        },
+        {
+          title: 'Seasonal Heat and Freeze Swings',
+          description:
+            'Keller irrigation systems need seasonal adjustments for summer heat, storm periods, and freeze risk. Preventive inspections can catch damaged heads, exposed pipe, and controller settings before they become larger issues.'
+        }
+      ]}
+      pricing={[
+        { label: 'Sprinkler Repair Visit', range: '$175-$450 typical scope' },
+        { label: 'Controller or Zone Optimization', range: '$250-$950 based on system needs' },
+        { label: 'Drainage Improvement', range: '$1,500-$6,500 based on layout' }
+      ]}
+      processSteps={[
+        'Ridgewood property walkthrough and irrigation concern review',
+        'Full-zone test for heads, valves, pressure, controller settings, and coverage',
+        'Clear repair or improvement recommendations before work begins',
+        'Clean sprinkler, irrigation, or drainage work using durable components',
+        'Final controller calibration and homeowner walkthrough'
+      ]}
+      faqs={[
+        {
+          question: 'Do you service older sprinkler systems in Ridgewood?',
+          answer:
+            'Yes. We inspect older systems for worn heads, valve leaks, wiring faults, low pressure, outdated controller settings, and coverage gaps, then recommend repairs or upgrades based on the condition of the system.'
+        },
+        {
+          question: 'Can you help reduce runoff from my sprinkler zones?',
+          answer:
+            'Yes. We look at nozzle type, head alignment, pressure, slope, and controller runtimes. In many cases, cycle-and-soak programming and targeted head adjustments can reduce runoff without sacrificing lawn health.'
+        },
+        {
+          question: 'Do Ridgewood homes need drainage work or sprinkler repair first?',
+          answer:
+            'It depends on the cause of the water problem. We test the sprinkler system first to rule out leaks or overspray, then evaluate grade, soil, and flow paths if the issue is stormwater or persistent pooling.'
+        },
+        {
+          question: 'Can you update my controller for Keller watering schedules?',
+          answer:
+            'Yes. We can review your controller programming, recommend efficient runtimes, and help set schedules that are easier to adjust as local watering guidance or seasonal conditions change.'
+        }
+      ]}
+      relatedAreas={[
+        {
+          name: 'Hidden Lakes',
+          description: 'Sprinkler repair, irrigation upgrades, and drainage support for larger Keller lots.',
+          link: '/keller/hidden-lakes'
+        },
+        {
+          name: 'Marshall Ridge',
+          description: 'HOA-focused irrigation tuning, leak repairs, and smart-controller optimization.',
+          link: '/keller/marshall-ridge'
+        },
+        {
+          name: 'Oakmont',
+          description: 'Targeted sprinkler repairs and drainage strategies for clay-heavy Keller soil.',
+          link: '/keller/oakmont'
+        }
+      ]}
+      popularServices={[
+        {
+          title: 'Sprinkler Repair',
+          description: 'Broken heads, leaking valves, controller issues, wiring problems, and uneven coverage corrections for Keller homes.',
+          link: '/keller/sprinkler-repair-services-in-keller-tx'
+        },
+        {
+          title: 'Irrigation Repair',
+          description: 'System-level diagnostics for zone performance, pressure balance, controller setup, and efficient watering.',
+          link: '/keller/irrigation-repair-services-in-keller-tx'
+        },
+        {
+          title: 'Drainage Solutions',
+          description: 'Drainage planning for low spots, side-yard runoff, patio pooling, and water movement after storms.',
+          link: '/services/drainage-solutions'
+        }
+      ]}
+      attractions={[
+        {
+          name: 'The Keller Pointe',
+          url: 'https://www.thekellerpointe.com/',
+          description: 'A well-used Keller recreation center with fitness, aquatics, and community amenities close to Ridgewood homes.'
+        },
+        {
+          name: 'Bear Creek Park',
+          url: 'https://www.cityofkeller.com/services-and-amenities/parks-trails/park-and-trail-directory/bear-creek-park',
+          description: 'A large local park with trails and open space that reflects the outdoor lifestyle many Keller residents value.'
+        },
+        {
+          name: 'Keller Town Center',
+          url: 'https://www.cityofkeller.com/government/departments/economic-development',
+          description: 'A central Keller destination for everyday dining, shopping, and community activity near surrounding neighborhoods.'
+        }
+      ]}
+      localLivingContent={
+        <>
+          <p>
+            Ridgewood homeowners are part of the broader Keller community served by the{' '}
+            <a
+              href="https://www.kellerisd.net/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4"
+            >
+              Keller Independent School District
+            </a>{' '}
+            and supported by nearby parks, trails, and recreation resources from the{' '}
+            <a
+              href="https://www.cityofkeller.com/services-and-amenities/parks-trails"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4"
+            >
+              Keller Parks and Recreation Department
+            </a>
+            . That mix of established neighborhoods and outdoor amenities makes reliable irrigation especially important for healthy lawns and usable yards.
+          </p>
+          <p>
+            Daily life in Keller also includes convenient access to the{' '}
+            <a
+              href="https://www.cityofkeller.com/services-and-amenities/library"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4"
+            >
+              Keller Public Library
+            </a>{' '}
+            and local dining such as{' '}
+            <a
+              href="https://www.decadentdessertbar.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4"
+            >
+              Decadent Dessert Bar
+            </a>{' '}
+            and{' '}
+            <a
+              href="https://www.devlivoak.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4"
+            >
+              DeVivo Bros. Eatery
+            </a>
+            , keeping errands, family plans, and weekend routines close to home.
+          </p>
+        </>
+      }
+    />
+  );
+}

--- a/src/data/locationData.ts
+++ b/src/data/locationData.ts
@@ -83,7 +83,11 @@ export const locationData = {
         description: 'Targeted repairs and drainage upgrades for clay-heavy soil conditions and seasonal heat stress.',
         link: '/keller/oakmont'
       },
-      'Ridgewood'
+      {
+        name: 'Ridgewood',
+        description: 'Prompt sprinkler diagnostics, coverage improvements, and drainage planning for established Keller lawns and landscape beds.',
+        link: '/keller/ridgewood'
+      }
     ],
     serviceAreas: ['Southlake', 'Colleyville', 'Watauga', 'North Richland Hills'],
     coordinates: {


### PR DESCRIPTION
## Summary
- Adds a thin Next.js route wrapper for `/keller/ridgewood`
- Adds the Ridgewood neighborhood implementation component using the shared neighborhood template
- Updates Keller `locationData` so the Ridgewood card links to the new page

## Files
- `src/app/keller/ridgewood/page.tsx`
- `src/components/neighborhoods/RidgewoodPage.tsx`
- `src/data/locationData.ts`

## Notes
- Canonical URL set to `https://sprinkleranddrains.com/keller/ridgewood`
- Metadata uses concrete Ridgewood/Keller copy with no placeholder tokens