### PR TITLE
Add Argyle Meadows sprinkler services page

### DIFF
--- a/src/app/argyle/argyle-meadows/page.tsx
+++ b/src/app/argyle/argyle-meadows/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import ArgyleMeadowsPage from '@/components/neighborhoods/ArgyleMeadowsPage';
+
+export const metadata: Metadata = {
+  title: 'Argyle Meadows Sprinkler Services | Argyle, TX | Texas Best Sprinklers',
+  description: 'Sprinkler repair, irrigation tune-ups, drainage planning, and outdoor lighting support for Argyle Meadows homeowners in Argyle, TX.',
+  alternates: {
+    canonical: 'https://sprinkleranddrains.com/argyle/argyle-meadows'
+  }
+};
+
+export default function ArgyleMeadowsArgylePage() {
+  return <ArgyleMeadowsPage />;
+}

--- a/src/components/neighborhoods/ArgyleMeadowsPage.tsx
+++ b/src/components/neighborhoods/ArgyleMeadowsPage.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import NeighborhoodPageTemplate from '@/components/templates/NeighborhoodPageTemplate';
+
+export default function ArgyleMeadowsPage() {
+  return (
+    <NeighborhoodPageTemplate
+      cityName='Argyle'
+      citySlug='argyle'
+      neighborhoodName='Argyle Meadows'
+      canonicalUrl='https://sprinkleranddrains.com/argyle/argyle-meadows'
+      pageTitle='Argyle Meadows Sprinkler Services in Argyle, TX'
+      metaDescription='Sprinkler repair, irrigation tune-ups, drainage planning, and outdoor lighting support for Argyle Meadows homeowners in Argyle, TX.'
+      heroTitle='Argyle Meadows Sprinkler Services in Argyle, TX'
+      heroDescription='Licensed irrigation, sprinkler repair, drainage, and lighting service for Argyle Meadows homes with North Texas clay soil, open lawn areas, and detailed landscape beds.'
+      introHeading='Irrigation Planning for Argyle Meadows Properties'
+      intro='Argyle Meadows homeowners need sprinkler systems that can handle long summer heat, shifting clay soil, and the mix of sunny turf, foundation-adjacent beds, and curb-facing landscape areas common across Argyle. Texas Best Sprinklers, Drainage and Lighting helps diagnose coverage problems, repair damaged components, tune controllers, and plan practical drainage improvements that protect lawns without wasting water.'
+      highlights={[
+        'Licensed irrigator service for Argyle Meadows homeowners who need dependable sprinkler diagnostics, repair, and seasonal calibration.',
+        'North Texas clay-soil watering strategies that help reduce runoff, pooling, and uneven turf stress during hot weather.',
+        'Controller programming, nozzle adjustments, and zone balancing for open lawns, side yards, and foundation-adjacent beds.',
+        'Drainage and grading recommendations for low spots, fence-line runoff, and areas that stay wet after heavy rain.'
+      ]}
+      serviceFocus={[
+        'Sprinkler repair for broken heads, leaking valves, low-pressure zones, and coverage gaps around turf and beds.',
+        'Irrigation repair and controller troubleshooting for systems that run inconsistently or waste water through poor scheduling.',
+        'Smart controller setup and seasonal runtime optimization for Argyle watering conditions.',
+        'Drainage solutions for standing water, clay soil saturation, and runoff near patios, fences, and foundations.',
+        'Outdoor lighting service for walkways, front entries, trees, and outdoor living spaces.'
+      ]}
+      localTips={[
+        'Use shorter cycle-and-soak watering windows so Argyle clay soil can absorb water instead of shedding it into the street or low areas.',
+        'Check spray patterns after mowing and seasonal growth because tilted heads can quickly create dry strips along sidewalks and beds.',
+        'Inspect valve boxes and low points after heavy rain to catch leaks or drainage problems before they affect turf health.',
+        'Adjust controller schedules during spring and fall so the system is not running like it is peak August heat.'
+      ]}
+      reviews={[
+        {
+          reviewer: 'Homeowner in Argyle Meadows',
+          date: 'March 2026',
+          quote: 'They found two coverage problems we had been missing and reset the controller so the front yard stopped drying out between cycles.'
+        },
+        {
+          reviewer: 'Argyle Meadows resident',
+          date: 'February 2026',
+          quote: 'Clear communication, clean work, and practical recommendations. The drainage issue near our side yard finally has a plan that makes sense.'
+        },
+        {
+          reviewer: 'Family near Argyle Meadows',
+          date: 'January 2026',
+          quote: 'Our sprinkler repair was handled quickly and the pricing was explained before the work started. The system is running much more evenly now.'
+        }
+      ]}
+      considerations={[
+        {
+          title: 'Open Lawns and Detailed Bed Lines',
+          description: 'Argyle Meadows properties often combine visible front turf with planted beds near walkways and entries. Proper nozzle selection and zone separation help keep curb appeal strong without overwatering shrubs or mulch areas.'
+        },
+        {
+          title: 'Clay Soil and Runoff Control',
+          description: 'Argyle sits in North Texas clay conditions where long watering cycles can create runoff before roots receive enough moisture. Cycle-and-soak programming and pressure checks help water move into the soil more effectively.'
+        },
+        {
+          title: 'Foundation-Aware Watering',
+          description: 'Sprinkler coverage near foundations should be consistent without spraying walls, windows, or hardscape. We tune heads and runtimes so beds and turf receive appropriate moisture while reducing overspray.'
+        },
+        {
+          title: 'Stormwater Movement After Heavy Rain',
+          description: 'Low areas, side yards, and fence lines can hold water after storms. Drainage planning helps move water away from problem zones while respecting the existing landscape layout.'
+        }
+      ]}
+      pricing={[
+        { label: 'Sprinkler Repair Visit', range: '$175-$450 typical scope' },
+        { label: 'Smart Controller Upgrade', range: '$450-$1,050 installed' },
+        { label: 'Drainage Improvement', range: '$1,500-$6,500 based on layout' }
+      ]}
+      processSteps={[
+        'Schedule an Argyle Meadows site assessment',
+        'Walk each zone and document pressure, coverage, leaks, and controller settings',
+        'Review repair, upgrade, or drainage recommendations before work begins',
+        'Complete clean repairs with durable components and careful landscape protection',
+        'Calibrate runtimes and provide practical maintenance guidance for seasonal changes'
+      ]}
+      faqs={[
+        {
+          question: 'Can you repair sprinkler systems in Argyle Meadows in one visit?',
+          answer: 'Most common repairs such as broken heads, minor leaks, clogged nozzles, and controller adjustments can often be completed in one visit when standard parts are available. Larger wiring, valve, or drainage issues may require a follow-up scope.'
+        },
+        {
+          question: 'Do you help reduce runoff on Argyle clay soil?',
+          answer: 'Yes. We look at pressure, nozzle output, slope, and controller programming, then recommend cycle-and-soak schedules or drainage improvements to help water soak in instead of running off.'
+        },
+        {
+          question: 'What sprinkler upgrades make sense for Argyle Meadows homes?',
+          answer: 'Common upgrades include smart controllers, matched precipitation nozzles, pressure-regulated heads, drip conversion for beds, and valve repairs that improve reliability and water efficiency.'
+        },
+        {
+          question: 'Can you also review drainage problems during a sprinkler visit?',
+          answer: 'Yes. If you have standing water, soggy turf, or runoff near a patio, fence, or foundation, we can evaluate those areas during the visit and recommend practical drainage options.'
+        }
+      ]}
+      relatedAreas={[
+        { name: 'Canyon Falls', description: 'Irrigation service and seasonal sprinkler tuning for nearby Argyle-area homes.', link: '/argyle' },
+        { name: 'Harvest', description: 'Sprinkler repair, controller adjustments, and drainage planning for growing landscape areas.', link: '/argyle' },
+        { name: 'Cross Oaks', description: 'Coverage troubleshooting and water-efficient irrigation support near Argyle Meadows.', link: '/argyle' }
+      ]}
+      popularServices={[
+        {
+          title: 'Sprinkler Repair',
+          description: 'Broken heads, valve leaks, wiring issues, low pressure, and uneven coverage corrections.',
+          link: '/services/sprinkler-repair'
+        },
+        {
+          title: 'Irrigation Repair',
+          description: 'System-level diagnostics for zone control, controller performance, pressure, and scheduling.',
+          link: '/services/irrigation-repair'
+        },
+        {
+          title: 'Drainage Solutions',
+          description: 'French drains, runoff planning, and practical fixes for low spots and pooling concerns.',
+          link: '/services/drainage-solutions'
+        }
+      ]}
+      attractions={[
+        {
+          name: 'Argyle Town Square',
+          url: 'https://sprinkleranddrains.com/argyle',
+          description: 'A local reference point for daily errands and community activity near Argyle Meadows.'
+        },
+        {
+          name: 'Liberty Christian School',
+          url: 'https://sprinkleranddrains.com/argyle',
+          description: 'A well-known Argyle landmark that reflects the community-focused character of the area.'
+        },
+        {
+          name: 'Cross Oaks Ranch',
+          url: 'https://sprinkleranddrains.com/argyle',
+          description: 'A nearby residential area that shares many of the same irrigation and drainage challenges as Argyle Meadows.'
+        }
+      ]}
+      localLivingContent={
+        <>
+          <p>
+            Argyle Meadows residents benefit from a quieter Denton County setting while still being close to established Argyle landmarks, nearby schools, and expanding residential communities. Irrigation systems in this part of town need to be tuned for open sun exposure, clay soil movement, and seasonal watering changes.
+          </p>
+          <p>
+            Texas Best Sprinklers, Drainage and Lighting serves the broader{' '}
+            <a
+              href='/argyle'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              Argyle service area
+            </a>{' '}
+            with sprinkler repair, drainage planning, and outdoor lighting support. Homeowners can also review our{' '}
+            <a
+              href='/services/sprinkler-repair'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              sprinkler repair services
+            </a>{' '}
+            or request help through the{' '}
+            <a
+              href='/contact'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              contact page
+            </a>
+            .
+          </p>
+        </>
+      }
+    />
+  );
+}

--- a/src/data/locationData.ts
+++ b/src/data/locationData.ts
@@ -17,7 +17,7 @@ export const LOCATIONS = [
   'blue-mound',
   'haslet',
   'north-richland-hills',
-  'trophy-club',    
+  'trophy-club',
   'arlington',
   'bedford',
   'euless',
@@ -258,7 +258,17 @@ export const locationData = {
     nearestOffice: 'Fort Worth',
     distanceFromOffice: 35,
     landmarks: ['Argyle Town Square', 'Liberty Christian School', 'Cross Oaks Ranch'],
-    neighborhoods: ['Canyon Falls', 'Harvest', 'Argyle Meadows', 'Cross Oaks', '5T Ranch'],
+    neighborhoods: [
+      'Canyon Falls',
+      'Harvest',
+      {
+        name: 'Argyle Meadows',
+        description: 'Sprinkler repair, irrigation tuning, drainage planning, and lighting support for Argyle Meadows homes and landscape beds.',
+        link: '/argyle/argyle-meadows'
+      },
+      'Cross Oaks',
+      '5T Ranch'
+    ],
     coordinates: {
       latitude: 33.1215,
       longitude: -97.1836


### PR DESCRIPTION
## Summary
- Adds the thin route wrapper for `/argyle/argyle-meadows`
- Adds the Argyle Meadows neighborhood implementation using the existing NeighborhoodPageTemplate structure
- Updates Argyle location data so the Argyle Meadows neighborhood card links to the new page

## Checks
- Canonical URL set to `https://sprinkleranddrains.com/argyle/argyle-meadows`
- City page wiring includes `link: '/argyle/argyle-meadows'`
- `serviceFocus`, `highlights`, `localTips`, and `processSteps` use string arrays per template requirements