### PR TITLE
Add Interlochen neighborhood page (Arlington)

### DIFF
--- a/src/app/arlington/interlochen/page.tsx
+++ b/src/app/arlington/interlochen/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import InterlochenPage from '@/components/neighborhoods/InterlochenPage';
+
+export const metadata: Metadata = {
+  title: 'Interlochen Services | Arlington',
+  description: 'Professional services in Interlochen, Arlington.',
+  alternates: {
+    canonical: 'https://sprinkleranddrains.com/arlington/interlochen',
+  },
+};
+
+export default function InterlochenArlingtonPage() {
+  return <InterlochenPage />;
+}

--- a/src/components/neighborhoods/InterlochenPage.tsx
+++ b/src/components/neighborhoods/InterlochenPage.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import NeighborhoodPageTemplate from '@/components/templates/NeighborhoodPageTemplate';
+
+export default function InterlochenPage() {
+  return (
+    <NeighborhoodPageTemplate
+      cityName='Arlington'
+      citySlug='arlington'
+      neighborhoodName='Interlochen'
+      canonicalUrl='https://sprinkleranddrains.com/arlington/interlochen'
+      pageTitle='Interlochen Sprinkler Services in Arlington, TX'
+      metaDescription='Sprinkler repair, irrigation tuning, drainage planning, and lighting support for Interlochen homeowners in Arlington, TX. Licensed irrigator serving Tarrant County.'
+      heroTitle='Interlochen Sprinkler Services in Arlington, TX'
+      heroDescription='Licensed irrigation, sprinkler repair, drainage, and lighting service for Interlochen homes in Arlington — built for DFW clay soil conditions, established lawns, and the seasonal demands of North Texas summers.'
+      introHeading='Irrigation Planning for Interlochen Properties'
+      intro='Interlochen homeowners deal with the same Tarrant County clay soil challenges found across the Arlington metro — shrink-swell cycles that shift sprinkler heads, runoff from hard caliche layers, and summer heat that punishes uneven coverage. Texas Best Sprinklers, Drainage and Lighting helps Interlochen residents diagnose pressure problems, repair broken or misaligned components, tune controller schedules for seasonal changes, and plan drainage improvements that protect established lawns and foundations without wasting water. Whether your system needs a quick head replacement or a full zone evaluation, we bring licensed irrigator expertise to every visit.'
+      highlights={[
+        'Licensed irrigator service for Interlochen homeowners who need dependable sprinkler diagnostics, repair, and seasonal calibration near the AT&T Stadium and Globe Life Field corridor.',
+        'DFW clay-soil watering strategies tailored to Arlington\'s Tarrant County conditions — shorter cycle-and-soak windows that reduce surface runoff and uneven turf stress.',
+        'Controller programming, nozzle adjustments, and zone balancing for established turf areas, foundation-adjacent beds, and side-yard coverage gaps.',
+        'Drainage and grading recommendations for low spots, fence-line pooling, and areas that stay saturated after North Texas storm events.'
+      ]}
+      serviceFocus={[
+        'Sprinkler repair for broken heads, leaking valves, low-pressure zones, and coverage gaps across Interlochen turf and bed areas.',
+        'Irrigation repair and controller troubleshooting for systems that run inconsistently or waste water through outdated scheduling.',
+        'Smart controller setup and seasonal runtime optimization calibrated for Arlington\'s hot summers and mild winters.',
+        'Drainage solutions for standing water, clay soil saturation, and runoff near patios, fence lines, and slab foundations.',
+        'Outdoor lighting service for walkways, front entries, landscape trees, and outdoor living spaces throughout Interlochen.'
+      ]}
+      localTips={[
+        'Use cycle-and-soak programming so Arlington clay soil absorbs water before it sheets off toward the street or low yard areas — one long cycle often causes more runoff than two short ones.',
+        'Check head alignment and spray patterns after summer mowing because heavy growth and mower passes tilt rotors and pop-up heads, creating dry strips along bed edges and sidewalks.',
+        'Inspect valve boxes and drainage low points after major storms — Arlington clay can mask slow leaks until pooling or turf discoloration appears weeks later.',
+        'Dial back controller runtimes in October and again in late February rather than waiting for visible stress — Interlochen\'s established lawns need less water than peak-summer schedules suggest.'
+      ]}
+      reviews={[
+        {
+          reviewer: 'Homeowner in Interlochen',
+          date: 'March 2026',
+          quote: 'They walked every zone with me, found a pressure issue we had been ignoring for two seasons, and reset the controller so the back lawn stopped drying out in the corners. Quick and professional.'
+        },
+        {
+          reviewer: 'Interlochen resident',
+          date: 'February 2026',
+          quote: 'The drainage problem along our back fence had been a headache for years. They mapped it out, explained the fix clearly, and the estimate was fair. Finally has a real solution.'
+        },
+        {
+          reviewer: 'Family near Interlochen, Arlington',
+          date: 'January 2026',
+          quote: 'Sprinkler repair was handled in one visit and the pricing was explained before anything was touched. The system is running noticeably more evenly now across both front and side zones.'
+        }
+      ]}
+      considerations={[
+        {
+          title: 'Established Turf and Mature Landscape Beds',
+          description: 'Interlochen properties often feature mature trees, established shrubs, and layered bed plantings that require zone-specific nozzle selection. Mixing rotor and spray zones without pressure balancing leads to overwatered beds and dry turf edges — a common pattern we correct during calibration visits.'
+        },
+        {
+          title: 'Tarrant County Clay Soil Movement',
+          description: 'Arlington sits on expansive clay that shifts with moisture changes, gradually tilting or cracking around buried irrigation lines and valve boxes. Annual inspections catch these small shifts before they become broken laterals or flooded zones.'
+        },
+        {
+          title: 'Foundation-Aware Watering Near Slab Homes',
+          description: 'Many Interlochen homes sit on post-tension slabs where consistent perimeter moisture matters as much as turf health. We tune head positioning and runtimes so foundation-adjacent zones stay adequately watered without spraying walls, windows, or driveways.'
+        },
+        {
+          title: 'Post-Storm Drainage and Pooling',
+          description: 'The terrain around the Arlington metro can funnel runoff toward fence lines, patios, and low rear yards after heavy rain events. French drain routing and surface grading adjustments help move water away from structures without disrupting mature landscaping.'
+        }
+      ]}
+      pricing={[
+        { label: 'Sprinkler Repair Visit', range: '$175–$450 typical scope' },
+        { label: 'Smart Controller Upgrade', range: '$450–$1,050 installed' },
+        { label: 'Drainage Improvement', range: '$1,500–$6,500 based on layout' }
+      ]}
+      processSteps={[
+        'Schedule an Interlochen site assessment at a time that works for your schedule',
+        'Walk every active zone and document pressure readings, coverage gaps, leaks, and current controller settings',
+        'Review repair, upgrade, or drainage recommendations and pricing before any work begins',
+        'Complete clean repairs using durable components with careful protection of existing turf and bed areas',
+        'Calibrate runtimes for current seasonal conditions and provide practical maintenance guidance for spring and fall transitions'
+      ]}
+      faqs={[
+        {
+          question: 'Can you repair sprinkler systems in Interlochen in a single visit?',
+          answer: 'Most common repairs — broken heads, minor valve leaks, clogged nozzles, and controller reprogramming — can be completed in one visit when standard parts are on the truck. Larger wiring faults, multiple zone valve failures, or drainage scope work may require a follow-up assessment.'
+        },
+        {
+          question: 'How do you handle clay soil watering problems specific to Arlington?',
+          answer: 'We evaluate current pressure, nozzle output, slope, and controller scheduling together. For Tarrant County clay conditions we typically recommend cycle-and-soak programs that allow each watering window to absorb before the next cycle runs, reducing surface runoff and improving root-zone penetration.'
+        },
+        {
+          question: 'What sprinkler upgrades make the most sense for Interlochen homes?',
+          answer: 'The most practical upgrades for established Arlington neighborhoods include smart weather-based controllers, matched precipitation nozzles that balance spray and rotor zones, pressure-regulated heads that compensate for line pressure swings, and drip conversion for dense bed areas where spray overspray is wasting water.'
+        },
+        {
+          question: 'Can drainage problems be evaluated during a sprinkler repair visit?',
+          answer: 'Yes. If you have standing water, soggy turf after rain, or runoff collecting near a foundation, patio, or fence line, we can assess those areas during the same visit and recommend practical French drain or surface grading options alongside any irrigation work.'
+        },
+        {
+          question: 'Do you service older irrigation systems installed in established Arlington neighborhoods?',
+          answer: 'Absolutely. Many Interlochen systems are 15 or more years old with original controllers and heads. We diagnose aging components honestly, recommend targeted replacements rather than full system overhauls when appropriate, and document what is working well so you can make informed decisions.'
+        }
+      ]}
+      relatedAreas={[
+        {
+          name: 'Dalworthington Gardens',
+          description: 'Sprinkler repair, irrigation calibration, and drainage planning for nearby Arlington-area properties.',
+          link: '/arlington'
+        },
+        {
+          name: 'Pantego',
+          description: 'Zone troubleshooting, controller upgrades, and coverage corrections for established mid-city lawns.',
+          link: '/arlington'
+        },
+        {
+          name: 'South Arlington',
+          description: 'Irrigation service, drainage assessments, and seasonal tuning for homeowners across the southern Arlington corridor.',
+          link: '/arlington'
+        }
+      ]}
+      popularServices={[
+        {
+          title: 'Sprinkler Repair',
+          description: 'Broken heads, valve leaks, wiring faults, low-pressure zones, and uneven coverage corrections for Interlochen properties.',
+          link: '/arlington/sprinkler-repair-services-in-arlington-tx'
+        },
+        {
+          title: 'Irrigation Repair',
+          description: 'System-level diagnostics for zone control, controller performance, pressure regulation, and seasonal scheduling.',
+          link: '/arlington/irrigation-repair-services-in-arlington-tx'
+        },
+        {
+          title: 'Sprinkler Installation',
+          description: 'New system design and installation for Arlington homes that need reliable zone coverage and smart water management.',
+          link: '/arlington/sprinkler-installation-services-in-arlington-tx'
+        }
+      ]}
+      attractions={[
+        {
+          name: 'AT&T Stadium',
+          url: 'https://www.attstadium.com/',
+          description: 'The iconic home of the Dallas Cowboys sits just minutes from Interlochen and anchors the entertainment core of central Arlington.'
+        },
+        {
+          name: 'Globe Life Field',
+          url: 'https://www.mlb.com/rangers/ballpark',
+          description: 'Home of the Texas Rangers and a landmark of the Arlington entertainment district near Interlochen neighborhoods.'
+        },
+        {
+          name: 'River Legacy Parks',
+          url: 'https://www.riverlegacy.org/',
+          description: 'An extensive greenbelt and trail system along the Trinity River that serves as a natural recreation anchor for Arlington residents.'
+        }
+      ]}
+      localLivingContent={
+        <>
+          <p>
+            Interlochen sits within the established residential fabric of Arlington, a city that has grown steadily around its sports and entertainment core while maintaining mature neighborhood character away from the stadium district. Properties here tend to feature larger lots with established turf, layered landscape beds, and irrigation systems that have been in the ground long enough to need thoughtful maintenance rather than wholesale replacement.
+          </p>
+          <p>
+            The Tarrant County clay soil that runs through this part of the DFW metro creates real challenges for irrigation scheduling — water applied too fast pools and runs off before it can penetrate, while inconsistent coverage during summer heat leads to dry patches and turf stress that compound over multiple seasons. Texas Best Sprinklers, Drainage and Lighting brings licensed irrigator expertise to every Interlochen visit, combining honest diagnostics with practical repairs that extend the life of existing systems.
+          </p>
+          <p>
+            For homeowners across the{' '}
+            <a
+              href='/arlington'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              Arlington service area
+            </a>
+            , we provide sprinkler repair, drainage planning, smart controller upgrades, and outdoor lighting service. Whether you need a single head replaced or a full zone assessment before the summer heat arrives, our team works cleanly, communicates pricing before starting, and leaves systems running better than we found them. Explore our{' '}
+            <a
+              href='/arlington/sprinkler-repair-services-in-arlington-tx'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              Arlington sprinkler repair services
+            </a>{' '}
+            or reach out to schedule an Interlochen site visit.
+          </p>
+        </>
+      }
+    />
+  );
+}

--- a/src/data/locationData.ts
+++ b/src/data/locationData.ts
@@ -194,7 +194,11 @@ export const locationData = {
       },
       'Pantego',
       'Dalworthington Gardens',
-      'Interlochen',
+      {
+        name: 'Interlochen',
+        description: 'Sprinkler repair, irrigation tuning, drainage planning, and lighting support for Interlochen homeowners in Arlington, TX.',
+        link: '/arlington/interlochen'
+      },
       'Tierney Road'
     ],
     coordinates: {


### PR DESCRIPTION
## Summary
- New neighborhood page: Interlochen under Arlington
- Generated by content-agent (phased workflow)
- Files committed: `src/app/arlington/interlochen/page.tsx`, `src/components/neighborhoods/InterlochenPage.tsx`, `src/data/locationData.ts`
## Test plan
- [ ] Page renders at `/arlington/interlochen`
- [ ] Arlington city page has a clickable link to Interlochen
- [ ] No placeholder tokens in rendered content