### PR TITLE
Add Pantego neighborhood page (Arlington)

### DIFF
--- a/src/app/arlington/pantego/page.tsx
+++ b/src/app/arlington/pantego/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import PantegoPage from '@/components/neighborhoods/PantegoPage';
+
+export const metadata: Metadata = {
+  title: 'Pantego Services | Arlington',
+  description: 'Professional services in Pantego, Arlington.',
+  alternates: {
+    canonical: 'https://sprinkleranddrains.com/arlington/pantego',
+  },
+};
+
+export default function PantegoArlingtonPage() {
+  return <PantegoPage />;
+}

--- a/src/components/neighborhoods/PantegoPage.tsx
+++ b/src/components/neighborhoods/PantegoPage.tsx
@@ -1,0 +1,221 @@
+import React from 'react';
+import NeighborhoodPageTemplate from '@/components/templates/NeighborhoodPageTemplate';
+
+export default function PantegoPage() {
+  return (
+    <NeighborhoodPageTemplate
+      cityName='Arlington'
+      citySlug='arlington'
+      neighborhoodName='Pantego'
+      canonicalUrl='https://sprinkleranddrains.com/arlington/pantego'
+      pageTitle='Pantego Sprinkler Services in Arlington, TX'
+      metaDescription='Sprinkler repair, irrigation tuning, drainage planning, and outdoor lighting support for Pantego homeowners in Arlington, TX. Licensed irrigator service for established properties in southwest Arlington.'
+      heroTitle='Pantego Sprinkler Services in Arlington, TX'
+      heroDescription='Licensed irrigation, sprinkler repair, drainage, and lighting service for Pantego homes with North Texas clay soil, mature trees, and established landscape beds in southwest Arlington.'
+      introHeading='Irrigation Planning for Pantego Properties'
+      intro='Pantego homeowners deal with the same clay-heavy soils, hot summers, and unpredictable storm seasons that challenge irrigation systems across the Arlington area. Many homes in this quiet enclave were built from the 1970s through the 1990s, meaning sprinkler systems may be aging, undersized, or poorly matched to modern watering needs. Texas Best Sprinklers, Drainage and Lighting helps Pantego property owners diagnose coverage problems, repair worn components, tune controllers for seasonal efficiency, and plan drainage improvements that protect mature landscaping and foundations without wasting water.'
+      highlights={[
+        'Licensed irrigator service for Pantego homeowners who need dependable sprinkler diagnostics, repair, and seasonal calibration in southwest Arlington.',
+        'North Texas clay-soil watering strategies tailored to established Pantego lawns with mature trees, large front yards, and mixed landscape beds.',
+        'Controller programming, nozzle adjustments, and zone balancing for turf areas, side yards, foundation-adjacent beds, and shaded planting zones.',
+        'Drainage and grading recommendations for low spots, fence-line runoff, and areas that pool after the heavy storms common to the Arlington area.',
+        'Outdoor lighting design and installation for walkways, front entries, trees, and outdoor living spaces on Pantego properties.'
+      ]}
+      serviceFocus={[
+        'Sprinkler repair for broken heads, leaking valves, low-pressure zones, and coverage gaps across Pantego turf and landscape beds.',
+        'Irrigation system diagnostics and controller troubleshooting for aging systems that run inconsistently or waste water through outdated scheduling.',
+        'Smart controller setup and seasonal runtime optimization calibrated to Arlington and Pantego watering conditions.',
+        'Drainage solutions for standing water, clay soil saturation, and runoff near patios, fence lines, and home foundations.',
+        'Outdoor lighting service for walkways, trees, front entries, and outdoor living spaces on established Pantego properties.'
+      ]}
+      localTips={[
+        'Use shorter cycle-and-soak watering windows so Pantego clay soil can absorb moisture rather than shedding it toward low areas or the street.',
+        'Check spray head alignment after mowing and seasonal growth spurts — tilted or blocked heads quickly create dry strips along walkways and bed edges.',
+        'Inspect valve boxes and low-lying yard areas after heavy Arlington storms to catch leaks or drainage problems before they affect turf health or foundations.',
+        'Scale back controller runtimes significantly in spring and fall so the system is not running on peak-summer schedules during cooler, wetter months.',
+        'Mature trees in Pantego can shade turf zones and create root intrusion risks near valve boxes — schedule annual checks to stay ahead of pressure and coverage changes.'
+      ]}
+      reviews={[
+        {
+          reviewer: 'Homeowner in Pantego',
+          date: 'March 2026',
+          quote: 'They found two zones that were barely reaching the back half of our yard and reset the controller so the lawn stopped drying out between cycles. Quick, clean work.'
+        },
+        {
+          reviewer: 'Pantego resident',
+          date: 'February 2026',
+          quote: 'Clear explanation of what was wrong, fair pricing, and the drainage issue near our fence line finally has a real plan. Glad we called.'
+        },
+        {
+          reviewer: 'Family near Pantego',
+          date: 'January 2026',
+          quote: 'Our system is running more evenly than it has in years. They handled a leaking valve and a broken head in one visit and took the time to walk us through the controller settings.'
+        }
+      ]}
+      considerations={[
+        {
+          title: 'Aging Irrigation Systems on Established Properties',
+          description: 'Many Pantego homes were built between the 1970s and 1990s, and sprinkler systems of that era often use outdated heads, worn valve diaphragms, and controllers that cannot handle modern water-efficiency programming. Upgrading components incrementally can restore coverage without a full system replacement.'
+        },
+        {
+          title: 'Clay Soil and Runoff Control',
+          description: 'Southwest Arlington sits on North Texas clay that expands with moisture and sheds water during long watering cycles. Cycle-and-soak programming and pressure checks help water penetrate the root zone instead of running off into low areas or neighboring properties.'
+        },
+        {
+          title: 'Mature Trees and Root Intrusion',
+          description: 'Pantego streets are lined with older shade trees that add to the neighborhood character but can shift valve boxes, create root intrusion near lateral lines, and shade turf zones unevenly. Periodic system checks help catch root-related damage before it becomes a larger repair.'
+        },
+        {
+          title: 'Foundation-Aware Watering',
+          description: 'Consistent sprinkler coverage near foundations is critical in clay soil environments where uneven moisture leads to slab movement. We tune heads and runtimes so beds and turf receive appropriate moisture without overspraying walls, windows, or hardscape.'
+        },
+        {
+          title: 'Stormwater Management After Heavy Rain',
+          description: 'Low areas, side yards, and older grading can hold water for days after Arlington storms. Drainage planning helps redirect runoff away from problem zones while working within the existing landscape layout common to Pantego properties.'
+        }
+      ]}
+      pricing={[
+        { label: 'Sprinkler Repair Visit', range: '$175–$450 typical scope' },
+        { label: 'Smart Controller Upgrade', range: '$450–$1,050 installed' },
+        { label: 'Drainage Improvement', range: '$1,500–$6,500 based on layout' },
+        { label: 'Outdoor Lighting Installation', range: '$800–$3,500 depending on fixture count and design' }
+      ]}
+      processSteps={[
+        'Schedule a Pantego site assessment at a time that works for your household',
+        'Walk each zone and document pressure, coverage gaps, leaks, and current controller settings',
+        'Review repair, upgrade, or drainage recommendations with pricing before any work begins',
+        'Complete clean repairs using durable components with careful protection of existing landscape and hardscape',
+        'Calibrate runtimes for current season and provide practical maintenance guidance for year-round Pantego conditions'
+      ]}
+      faqs={[
+        {
+          question: 'Can you repair sprinkler systems in Pantego in a single visit?',
+          answer: 'Most common repairs — broken heads, minor valve leaks, clogged nozzles, and controller adjustments — can typically be completed in one visit when standard parts are on the truck. Larger issues such as wiring faults, main valve failures, or drainage work may require a follow-up scope and quote.'
+        },
+        {
+          question: 'Do you work on older irrigation systems common in Pantego homes?',
+          answer: 'Yes. Many Pantego properties have systems installed in the 1980s or 1990s that still function but need updated heads, valve diaphragms, or controllers. We diagnose what is repairable versus what benefits from a targeted upgrade and walk you through the options before doing any work.'
+        },
+        {
+          question: 'How do you handle runoff and drainage problems on clay-soil properties?',
+          answer: 'We evaluate pressure, nozzle output, slope, soil conditions, and controller schedules, then recommend cycle-and-soak programming, drainage grading, or French drain solutions depending on where the water is moving and how quickly the soil absorbs it.'
+        },
+        {
+          question: 'Can you review drainage issues during a sprinkler repair visit?',
+          answer: 'Yes. If you have standing water, soggy turf patches, or runoff near a patio, fence, or foundation, we can evaluate those areas during the same visit and outline practical drainage options without requiring a separate appointment.'
+        },
+        {
+          question: 'What smart controller options work well for Pantego homes?',
+          answer: 'Weather-based smart controllers that adjust runtimes automatically based on local conditions work well for Arlington-area clay soils. They reduce water waste during cooler months and help keep coverage consistent during summer heat without requiring manual schedule changes.'
+        }
+      ]}
+      relatedAreas={[
+        {
+          name: 'Dalworthington Gardens',
+          description: 'Neighboring community sharing similar clay-soil irrigation and drainage challenges just outside Pantego.',
+          link: '/arlington'
+        },
+        {
+          name: 'Southwest Arlington',
+          description: 'Sprinkler repair, controller upgrades, and drainage planning for established homes throughout southwest Arlington.',
+          link: '/arlington'
+        },
+        {
+          name: 'Arlington Highlands Area',
+          description: 'Irrigation and drainage service for properties near the Arlington Highlands retail and residential corridor.',
+          link: '/arlington'
+        }
+      ]}
+      popularServices={[
+        {
+          title: 'Sprinkler Repair',
+          description: 'Broken heads, valve leaks, wiring issues, low pressure, and uneven coverage corrections for Pantego properties.',
+          link: '/arlington/sprinkler-repair-services-in-arlington-tx'
+        },
+        {
+          title: 'Irrigation Repair',
+          description: 'System-level diagnostics for zone control, controller performance, pressure regulation, and scheduling efficiency.',
+          link: '/arlington/irrigation-repair-services-in-arlington-tx'
+        },
+        {
+          title: 'Sprinkler Installation',
+          description: 'New irrigation system design and installation for Pantego homes upgrading from outdated or partial coverage setups.',
+          link: '/arlington/sprinkler-installation-services-in-arlington-tx'
+        }
+      ]}
+      attractions={[
+        {
+          name: 'Pantego Town Hall',
+          url: 'https://www.townofpantego.com',
+          description: 'The civic center of the incorporated town of Pantego, serving residents with local government services in southwest Arlington.'
+        },
+        {
+          name: 'River Legacy Parks',
+          url: 'https://www.riverlegacy.org',
+          description: 'A major Arlington nature preserve with trails, wetlands, and green space just a short drive from Pantego neighborhoods.'
+        },
+        {
+          name: 'Arlington Highlands',
+          url: 'https://www.google.com/maps/place/Arlington+Highlands,+Arlington,+TX',
+          description: 'A popular retail and dining destination close to Pantego with restaurants, shops, and entertainment options for the whole family.'
+        }
+      ]}
+      localLivingContent={
+        <>
+          <p>
+            Tucked into southwest Arlington, the town of Pantego feels like a small community layered inside the larger city. Although it is its own incorporated town, homeowners here move easily between Pantego and{' '}
+            <a
+              href='/arlington'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              Arlington
+            </a>{' '}
+            for work, school, shopping, and entertainment, creating a seamless daily routine. With just a couple of square miles to its name and a modest population, streets are relatively quiet, and neighbors often recognize one another, which adds to the close-knit feel.
+          </p>
+          <p>
+            Housing in Pantego and this part of Arlington is largely made up of single-family homes on established streets, along with a mix of smaller homes, duplexes, and some apartment communities. Many properties were built from the 1970s through the 1990s, with some older houses dating back to the mid-20th century, so it is common to see mature trees, big front yards, and a variety of architectural styles on the same block. These older homes often prompt projects like foundation maintenance, updating irrigation systems, and modernizing landscaping to handle North Texas weather.
+          </p>
+          <p>
+            Because Pantego is surrounded by Arlington and Dalworthington Gardens, residents are never far from parks and green space. Neighborhood parks and nearby city facilities give families places to walk the dog, let kids run, or enjoy youth sports. Mature shade trees are a hallmark of many streets, but they can also contribute to root intrusions, leaf buildup, and drainage issues that local homeowners have to manage — often with help from irrigation and{' '}
+            <a
+              href='/arlington/irrigation-repair-services-in-arlington-tx'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              drainage repair professionals
+            </a>{' '}
+            familiar with the area.
+          </p>
+          <p>
+            Families living in Pantego typically connect into Arlington's broader network of schools and educational programs, depending on zoning and grade level. Options in and around the area include public schools, private campuses, and faith-based academies, so most families can find something that fits their needs without a long commute. Proximity to Arlington's libraries, recreation centers, and youth activities makes after-school schedules easier to juggle.
+          </p>
+          <p>
+            Commute times from Pantego and southwest Arlington are generally manageable, which is part of the area's appeal for working households. Many residents drive 15 to 30 minutes to reach major employment centers in Arlington, Fort Worth, or other nearby cities, with most people commuting by car on local arterials and regional highways. Quick access to routes toward I-20 and other major roads helps homeowners balance suburban living with city jobs.
+          </p>
+          <p>
+            The local lifestyle in Pantego blends small-town rhythms with Arlington's big-city amenities. Residents can spend a morning at a neighborhood café or local shop, then be at a major Arlington attraction, shopping center, or restaurant corridor in just a few minutes. Weekends often revolve around home projects, kids' activities, and outdoor time in the yard or at nearby parks, especially when the weather cooperates.
+          </p>
+          <p>
+            Property challenges in this part of Arlington reflect typical North Texas realities. Clay-heavy soils and hot, dry summers put stress on foundations, lawns, and irrigation systems, so homeowners pay close attention to watering patterns and drainage around the house. Periodic heavy storms can overwhelm older gutters or poorly graded yards, leading many Pantego property owners to upgrade{' '}
+            <a
+              href='/arlington/sprinkler-repair-services-in-arlington-tx'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              sprinkler systems
+            </a>{' '}
+            and fine-tune drainage coverage over time.
+          </p>
+          <p>
+            Overall, Pantego offers Arlington homeowners a quiet, established environment with the convenience of nearby city services. The mix of aging homes, mature trees, and changing weather patterns keeps maintenance on the radar, but it also gives the neighborhood its character and long-term appeal. Texas Best Sprinklers, Drainage and Lighting serves the{' '}
+            <a
+              href='/arlington'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              Arlington service area
+            </a>{' '}
+            including Pantego with licensed irrigation repair, drainage planning, and outdoor lighting support for homeowners who want reliable results and straightforward pricing.
+          </p>
+        </>
+      }
+    />
+  );
+}

--- a/src/data/locationData.ts
+++ b/src/data/locationData.ts
@@ -192,7 +192,11 @@ export const locationData = {
         description: 'Sprinkler repair, irrigation tuning, drainage planning, and lighting support for Viridian homeowners in Arlington, TX.',
         link: '/arlington/viridian'
       },
-      'Pantego',
+      {
+        name: 'Pantego',
+        description: 'Sprinkler repair, irrigation tuning, drainage planning, and lighting support for Pantego homeowners in Arlington, TX.',
+        link: '/arlington/pantego'
+      },
       'Dalworthington Gardens',
       {
         name: 'Interlochen',


### PR DESCRIPTION
## Summary
- New neighborhood page: Pantego under Arlington
- Generated by content-agent (phased workflow)
- Files committed: `src/app/arlington/pantego/page.tsx`, `src/components/neighborhoods/PantegoPage.tsx`, `src/data/locationData.ts`
## Test plan
- [ ] Page renders at `/arlington/pantego`
- [ ] Arlington city page has a clickable link to Pantego
- [ ] No placeholder tokens in rendered content