### PR TITLE
Add Dalworthington Gardens neighborhood page (Arlington)

### DIFF
--- a/src/app/arlington/dalworthington-gardens/page.tsx
+++ b/src/app/arlington/dalworthington-gardens/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import DalworthingtonGardensPage from '@/components/neighborhoods/DalworthingtonGardensPage';
+
+export const metadata: Metadata = {
+  title: 'Dalworthington Gardens Services | Arlington',
+  description: 'Professional services in Dalworthington Gardens, Arlington.',
+  alternates: {
+    canonical: 'https://sprinkleranddrains.com/arlington/dalworthington-gardens',
+  },
+};
+
+export default function DalworthingtonGardensArlingtonPage() {
+  return <DalworthingtonGardensPage />;
+}

--- a/src/components/neighborhoods/DalworthingtonGardensPage.tsx
+++ b/src/components/neighborhoods/DalworthingtonGardensPage.tsx
@@ -1,0 +1,253 @@
+import React from 'react';
+import NeighborhoodPageTemplate from '@/components/templates/NeighborhoodPageTemplate';
+
+export default function DalworthingtonGardensPage() {
+  return (
+    <NeighborhoodPageTemplate
+      cityName='Arlington'
+      citySlug='arlington'
+      neighborhoodName='Dalworthington Gardens'
+      canonicalUrl='https://sprinkleranddrains.com/arlington/dalworthington-gardens'
+      pageTitle='Dalworthington Gardens Sprinkler Services in Arlington, TX'
+      metaDescription='Sprinkler repair, irrigation tuning, drainage planning, and lighting support for Dalworthington Gardens homeowners in Arlington, TX — a small enclave city surrounded by Arlington with larger lots and mature trees.'
+      heroTitle='Dalworthington Gardens Sprinkler Services in Arlington, TX'
+      heroDescription='Licensed sprinkler repair, irrigation diagnostics, drainage planning, and outdoor lighting service for Dalworthington Gardens homes — a small incorporated enclave with larger lots, mature trees, and North Texas clay soil that demands thoughtful water management.'
+      introHeading='Irrigation and Drainage Service for Dalworthington Gardens Properties'
+      intro='Dalworthington Gardens homeowners deal with a unique combination of challenges: larger semi-rural lots, mature tree coverage, clay-heavy soil, and the same North Texas summer heat that stresses every lawn in the region. Texas Best Sprinklers, Drainage and Lighting provides sprinkler repair, irrigation diagnostics, controller tuning, and drainage improvements tailored to the wider coverage areas, sloped terrain, and foundation concerns common across this distinct enclave city nestled inside Arlington.'
+      highlights={[
+        'Licensed irrigator service for Dalworthington Gardens homeowners managing larger lots, mature trees, and clay soil irrigation challenges.',
+        'Clay-soil watering strategies that reduce runoff, standing water, and uneven turf stress on the semi-rural properties common throughout this enclave.',
+        'Zone balancing, nozzle adjustments, and controller programming for wide open turf, foundation-adjacent beds, and shaded areas under established trees.',
+        'Drainage planning for larger lots with low spots, fence-line pooling, and runoff that builds up in heavy North Texas storms.',
+        'Seasonal calibration to align irrigation runtimes with actual weather conditions and regional water conservation guidelines.'
+      ]}
+      serviceFocus={[
+        'Sprinkler repair for broken heads, leaking valves, low-pressure zones, and uneven coverage across larger Dalworthington Gardens lots.',
+        'Irrigation repair and controller troubleshooting for systems that run inconsistently, waste water, or fail to reach full coverage across wide zones.',
+        'Smart controller setup and runtime optimization calibrated for Arlington-area clay soil and seasonal watering demands.',
+        'Drainage solutions for standing water, saturated clay soil, and runoff near patios, fence lines, and foundations on semi-rural properties.',
+        'Outdoor lighting service for driveways, entries, mature trees, garden beds, and outdoor living areas throughout the neighborhood.'
+      ]}
+      localTips={[
+        'Use cycle-and-soak watering schedules so Arlington clay soil can absorb water gradually rather than shedding it across flat or sloped turf areas.',
+        'Inspect heads after seasonal mowing because taller turf growth and shifting clay soil can tilt nozzles and create dry strips or overspray onto hardscape.',
+        'Check valve boxes and drainage low points after heavy storms — larger lots in Dalworthington Gardens can accumulate runoff from multiple directions.',
+        'Adjust controller runtimes in spring and fall to avoid overwatering during cooler seasons when evapotranspiration rates are much lower than summer.',
+        'Foundation-adjacent zones deserve careful head placement and runtime limits since clay soil swells and contracts significantly with wet-dry cycles.'
+      ]}
+      reviews={[
+        {
+          reviewer: 'Homeowner in Dalworthington Gardens',
+          date: 'March 2026',
+          quote: 'We have a large yard with several mature oaks and the coverage was really uneven. They mapped every zone, replaced several heads, and reprogrammed the controller so everything runs evenly now.'
+        },
+        {
+          reviewer: 'Dalworthington Gardens resident',
+          date: 'February 2026',
+          quote: 'Standing water near our back fence had been a problem for years. The drainage assessment was thorough and the fix made a real difference after the next round of storms.'
+        },
+        {
+          reviewer: 'Family in Dalworthington Gardens',
+          date: 'January 2026',
+          quote: 'Honest pricing, careful work around our garden beds, and a clear explanation of what was wrong before they started. The system runs much more consistently across the full property now.'
+        }
+      ]}
+      considerations={[
+        {
+          title: 'Larger Lots and Wide Coverage Zones',
+          description: 'Dalworthington Gardens properties are often significantly larger than typical suburban lots, requiring more zones, matched precipitation nozzles, and careful pressure management to deliver even coverage from the front curb to the back fence line.'
+        },
+        {
+          title: 'Mature Tree Coverage and Root Competition',
+          description: 'Established trees shade large portions of many yards and their root systems can interfere with underground irrigation lines over time. We adjust head placement and runtimes to account for varying light conditions and inspect lateral lines in root-dense zones.'
+        },
+        {
+          title: 'Clay Soil and Foundation Watering',
+          description: 'North Texas clay soil contracts sharply during drought and expands with heavy rain, creating movement that affects foundations and underground lines alike. Consistent, calibrated watering near foundations and cycle-and-soak schedules help reduce the stress cycle.'
+        },
+        {
+          title: 'Drainage on Semi-Rural Parcels',
+          description: 'Larger properties can funnel runoff from multiple directions into low spots, side yards, or near structures. French drains, grading adjustments, and catch basins help move water away from foundations and protect turf on parcels where standard suburban drainage is not sufficient.'
+        }
+      ]}
+      pricing={[
+        { label: 'Sprinkler Repair Visit', range: '$175–$475 typical scope' },
+        { label: 'Smart Controller Upgrade', range: '$450–$1,100 installed' },
+        { label: 'Drainage Improvement', range: '$1,500–$7,500 based on lot size and layout' },
+        { label: 'Full System Tune-Up', range: '$225–$550 depending on zone count' }
+      ]}
+      processSteps={[
+        'Schedule a Dalworthington Gardens site assessment at a time that works for your property and schedule',
+        'Walk every zone, document pressure readings, head placement, coverage gaps, leaks, and controller settings',
+        'Review repair, upgrade, or drainage recommendations with transparent pricing before any work begins',
+        'Complete clean, durable repairs using quality components with careful protection of existing beds, trees, and landscape features',
+        'Calibrate controller runtimes and provide seasonal maintenance guidance specific to Dalworthington Gardens conditions'
+      ]}
+      faqs={[
+        {
+          question: 'Can you service larger lots in Dalworthington Gardens with multiple irrigation zones?',
+          answer: 'Yes. We regularly work on properties with six or more zones, mixed nozzle types, and aging controllers. We map each zone during the assessment and prioritize repairs by coverage impact and water waste.'
+        },
+        {
+          question: 'How do you handle irrigation near mature trees in Dalworthington Gardens?',
+          answer: 'We check for root intrusion on lateral lines, adjust head arcs to avoid heavy shade zones where turf struggles, and can recommend drip conversion for beds under tree canopies where spray irrigation wastes water.'
+        },
+        {
+          question: 'Can you help with drainage problems on semi-rural lots?',
+          answer: 'Yes. We evaluate slope, soil type, existing drainage paths, and problem areas like low spots and fence lines, then recommend practical solutions such as French drains, catch basins, or regrading that work within the scale of larger Dalworthington Gardens properties.'
+        },
+        {
+          question: 'Do you follow Arlington and regional water conservation guidelines?',
+          answer: 'Yes. We program controllers in accordance with local watering schedules and can set up smart controllers that automatically adjust based on weather data and evapotranspiration rates, helping homeowners stay compliant and reduce waste.'
+        },
+        {
+          question: 'Can sprinkler and drainage issues be addressed in the same visit?',
+          answer: 'In most cases, yes. If you have both irrigation coverage problems and standing water concerns, we evaluate both during the site visit and can often address minor drainage observations as part of a combined repair scope.'
+        }
+      ]}
+      relatedAreas={[
+        {
+          name: 'Arlington',
+          description: 'Full sprinkler repair, irrigation service, drainage planning, and outdoor lighting across the broader Arlington service area.',
+          link: '/arlington'
+        },
+        {
+          name: 'Pantego',
+          description: 'Sprinkler repair and drainage service for this small incorporated community also surrounded by Arlington.',
+          link: '/arlington'
+        },
+        {
+          name: 'Kennedale',
+          description: 'Irrigation tuning, sprinkler diagnostics, and drainage planning for homeowners in the Kennedale area near Arlington.',
+          link: '/arlington'
+        }
+      ]}
+      popularServices={[
+        {
+          title: 'Sprinkler Repair',
+          description: 'Broken heads, valve leaks, wiring faults, low pressure, and uneven coverage corrections across full properties.',
+          link: '/arlington/sprinkler-repair-services-in-arlington-tx'
+        },
+        {
+          title: 'Irrigation Repair',
+          description: 'System-level diagnostics covering zone control, controller performance, pressure regulation, and scheduling.',
+          link: '/arlington/irrigation-repair-services-in-arlington-tx'
+        },
+        {
+          title: 'Sprinkler Installation',
+          description: 'New system design and installation for larger lots, new construction, or properties with outdated irrigation infrastructure.',
+          link: '/arlington/sprinkler-installation-services-in-arlington-tx'
+        }
+      ]}
+      attractions={[
+        {
+          name: 'City of Dalworthington Gardens',
+          url: 'https://www.cityofdwg.net',
+          description: 'The official city website for Dalworthington Gardens, covering local government, public services, and community resources for residents.'
+        },
+        {
+          name: 'Arlington Parks and Recreation',
+          url: 'https://www.arlingtontx.gov/city_hall/departments/parks_recreation',
+          description: 'Parks, trails, and recreation facilities maintained by the City of Arlington and accessible to Dalworthington Gardens residents nearby.'
+        },
+        {
+          name: 'Arlington Independent School District',
+          url: 'https://www.aisd.net',
+          description: 'The school district serving Dalworthington Gardens families with elementary, junior high, and high school campuses throughout Arlington.'
+        },
+        {
+          name: 'Tarrant Regional Water District',
+          url: 'https://www.trwd.com',
+          description: 'Regional water authority providing conservation guidance, drought restrictions, and water management resources relevant to Dalworthington Gardens homeowners.'
+        }
+      ]}
+      localLivingContent={
+        <>
+          <p>
+            Tucked between major Arlington corridors yet maintaining its own identity, Dalworthington Gardens is a small, incorporated city that feels like a rural pocket in the middle of the Metroplex. Originally developed in the 1930s as a homestead community, it still has a semi-rural character, with larger lots, mature trees, and a quieter pace than many nearby{' '}
+            <a
+              href='/arlington'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              Arlington
+            </a>{' '}
+            neighborhoods. Many homes sit back from the road, and it is common to see spacious yards, small barns, and gardens alongside newer construction.
+          </p>
+          <p>
+            Dalworthington Gardens is closely tied to Arlington for shopping, dining, and entertainment, with residents using nearby thoroughfares such as Pioneer Parkway, Arkansas Lane, and Bowen Road to reach the rest of the city. Its location between I-20 and I-30 gives homeowners relatively direct freeway access toward downtown Fort Worth or Dallas for commuters. Daily errands often stay close to home, however, with neighborhood retail and services clustered along border streets in Arlington.
+          </p>
+          <p>
+            The city maintains its own government and public services through the{' '}
+            <a
+              href='https://www.cityofdwg.net'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              City of Dalworthington Gardens
+            </a>
+            , giving residents a local point of contact for water, streets, and code issues. Homeowners interested in building, remodeling, or adding outbuildings typically work with both Dalworthington Gardens officials and broader Tarrant County or Arlington-area requirements, depending on the project type and utility connections. Because many properties are larger and semi-rural in character, questions about fencing, accessory structures, and land use are common.
+          </p>
+          <p>
+            Families in Dalworthington Gardens are served by the Arlington public school system, including campuses in the{' '}
+            <a
+              href='https://www.aisd.net'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              Arlington Independent School District
+            </a>
+            . Nearby elementary, junior high, and high schools in Arlington provide a range of academic and extracurricular options, and school events are an important part of neighborhood life. Many students participate in local sports leagues and activities that draw families from both Dalworthington Gardens and surrounding Arlington communities.
+          </p>
+          <p>
+            Green space is a defining feature of the area. Within its small city limits, Dalworthington Gardens offers tree-lined streets, ponds, and open fields, while Arlington's park system adds even more recreation options close by. Residents frequently visit nearby facilities managed by{' '}
+            <a
+              href='https://www.arlingtontx.gov/city_hall/departments/parks_recreation'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              Arlington Parks and Recreation
+            </a>
+            , including neighborhood parks, trails, and sports fields just a short drive away. Walking, jogging, and dog-walking along residential roads are part of the everyday routine.
+          </p>
+          <p>
+            Because the neighborhood blends rural-style lots with suburban infrastructure, homeowners often pay close attention to water use, drainage, and outdoor maintenance. The City of Arlington's{' '}
+            <a
+              href='https://www.arlingtontx.gov/city_hall/departments/water_utilities'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              water utilities department
+            </a>{' '}
+            and the{' '}
+            <a
+              href='https://www.trwd.com'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              Tarrant Regional Water District
+            </a>{' '}
+            offer information on conservation, drought restrictions, and responsible landscape watering that applies to many Dalworthington Gardens residents who rely on regional supplies. In heavy North Texas storms, proper grading, French drains, and well-maintained{' '}
+            <a
+              href='/arlington/sprinkler-repair-services-in-arlington-tx'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              sprinkler systems
+            </a>{' '}
+            help protect foundations and manage runoff on the larger properties common in the area.
+          </p>
+          <p>
+            Local codes and best practices for irrigation, backflow prevention, and water-efficient landscaping are shaped in part by Arlington and regional regulations, so homeowners often consult both city and district resources when planning yard improvements. With clay soils typical of Arlington and Dalworthington Gardens, seasonal shifts can affect foundations, driveways, and underground lines, making ongoing outdoor maintenance a regular part of homeownership here.
+          </p>
+          <p>
+            Despite being surrounded by a major urban area, Dalworthington Gardens retains a small-town feel where residents often recognize one another at nearby schools, parks, and community events. The combination of rural charm, convenient Arlington access, and a strong emphasis on property upkeep and outdoor living makes this neighborhood distinct within Tarrant County.
+          </p>
+        </>
+      }
+    />
+  );
+}

--- a/src/data/locationData.ts
+++ b/src/data/locationData.ts
@@ -197,7 +197,11 @@ export const locationData = {
         description: 'Sprinkler repair, irrigation tuning, drainage planning, and lighting support for Pantego homeowners in Arlington, TX.',
         link: '/arlington/pantego'
       },
-      'Dalworthington Gardens',
+      {
+        name: 'Dalworthington Gardens',
+        description: 'Sprinkler repair, irrigation tuning, drainage planning, and lighting support for Dalworthington Gardens homeowners in Arlington, TX.',
+        link: '/arlington/dalworthington-gardens'
+      },
       {
         name: 'Interlochen',
         description: 'Sprinkler repair, irrigation tuning, drainage planning, and lighting support for Interlochen homeowners in Arlington, TX.',


### PR DESCRIPTION
## Summary
- New neighborhood page: Dalworthington Gardens under Arlington
- Generated by content-agent (phased workflow)
- Files committed: `src/app/arlington/dalworthington-gardens/page.tsx`, `src/components/neighborhoods/DalworthingtonGardensPage.tsx`, `src/data/locationData.ts`
## Test plan
- [ ] Page renders at `/arlington/dalworthington-gardens`
- [ ] Arlington city page has a clickable link to Dalworthington Gardens
- [ ] No placeholder tokens in rendered content