### PR TITLE
Add Entrada neighborhood page (Westlake)

### DIFF
--- a/src/app/westlake/entrada/page.tsx
+++ b/src/app/westlake/entrada/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import EntradaPage from '@/components/neighborhoods/EntradaPage';
+
+export const metadata: Metadata = {
+  title: 'Entrada Services | Westlake',
+  description: 'Professional services in Entrada, Westlake.',
+  alternates: {
+    canonical: 'https://sprinkleranddrains.com/westlake/entrada',
+  },
+};
+
+export default function EntradaWestlakePage() {
+  return <EntradaPage />;
+}

--- a/src/components/neighborhoods/EntradaPage.tsx
+++ b/src/components/neighborhoods/EntradaPage.tsx
@@ -1,0 +1,283 @@
+import React from 'react';
+import NeighborhoodPageTemplate from '@/components/templates/NeighborhoodPageTemplate';
+
+export default function EntradaPage() {
+  return (
+    <NeighborhoodPageTemplate
+      cityName='Westlake'
+      citySlug='westlake'
+      neighborhoodName='Entrada'
+      canonicalUrl='https://sprinkleranddrains.com/westlake/entrada'
+      pageTitle='Entrada Sprinkler Services in Westlake, TX'
+      metaDescription='Sprinkler repair, irrigation tuning, drainage planning, and lighting support for Entrada homeowners in Westlake, TX. Licensed irrigator service for estate-scale properties in this European-village community.'
+      heroTitle='Entrada Sprinkler Services in Westlake, TX'
+      heroDescription='Licensed irrigation, sprinkler repair, drainage, and lighting service for Entrada homes featuring shared streetscapes, courtyard plantings, manicured landscape beds, and estate-scale irrigation demands in Westlake, TX.'
+      introHeading='Irrigation Planning for Entrada Properties in Westlake'
+      intro='Entrada homeowners manage some of the most thoughtfully designed landscapes in North Texas — European-style plazas, intimate courtyard plantings, walkable promenades, and manicured beds that frame luxury townhomes and villas. Irrigation systems in this village-format community need precise calibration to protect delicate plantings without overshooting shared walkways, courtyards, or neighboring structures. Texas Best Sprinklers, Drainage and Lighting provides licensed irrigator service tailored to Entrada properties: diagnosing coverage gaps, repairing aging components, tuning controllers for seasonal shifts, and planning drainage improvements that keep water moving away from tight lot lines and shared streetscapes.'
+      highlights={[
+        'Licensed irrigator service for Entrada homeowners managing estate-caliber landscape beds, courtyard plantings, and village-style shared greenspace.',
+        'Precision nozzle selection and zone calibration to protect pedestrian promenades, shared walls, and ornamental plantings without overspray.',
+        'Seasonal controller programming optimized for Westlake summer heat, periodic drought stages, and Tarrant Regional Water District watering guidelines.',
+        'Drainage assessment and planning for tight lot lines, shared streetscapes, and low points that collect runoff after North Texas storm events.',
+        'Outdoor lighting diagnostics, fixture repair, and new lighting design for Entrada entries, walkways, water features, and ornamental trees.'
+      ]}
+      serviceFocus={[
+        'Sprinkler repair for broken heads, leaking valves, low-pressure zones, and coverage gaps around Entrada courtyard beds, turf panels, and ornamental plantings.',
+        'Irrigation repair and controller troubleshooting for systems that run inconsistently or waste water through poor scheduling on estate-scale Westlake properties.',
+        'Smart controller installation and seasonal runtime optimization aligned with Tarrant Regional Water District conservation and drought contingency programs.',
+        'Drainage solutions for standing water, grading issues, and runoff near shared walkways, courtyard walls, patios, and building foundations in Entrada.',
+        'Outdoor lighting service for Entrada entries, promenade landscapes, ornamental trees, water features, and private courtyard spaces.',
+        'Zone balancing and nozzle upgrades to prevent overspray onto Entrada streets, shared hardscape surfaces, and neighboring structures.'
+      ]}
+      localTips={[
+        'Use cycle-and-soak watering programs so North Texas clay soils beneath Entrada beds absorb moisture slowly rather than shedding runoff onto shared walkways and streets.',
+        'Inspect spray patterns after any landscape trimming or seasonal growth flush — tilted heads near courtyard walls can quickly create dry strips or overspray problems on adjacent hardscape.',
+        'Check valve boxes and drainage low points after heavy rain to catch leaks or ponding before standing water affects ornamental plantings or building foundations.',
+        'Adjust controller runtimes every spring and fall — Westlake summer irrigation needs are significantly different from fall shoulder-season requirements, and over-scheduling in cooler months stresses beds unnecessarily.',
+        'Stay current with Tarrant Regional Water District watering schedules and any drought-stage restrictions so your system stays compliant without guesswork.'
+      ]}
+      reviews={[
+        {
+          reviewer: 'Homeowner in Entrada, Westlake',
+          date: 'April 2026',
+          quote: 'Our courtyard beds were getting uneven coverage and we had a slow leak near one of the plazas. They diagnosed both problems in one visit and reset the controller so each zone is actually running the right amount.'
+        },
+        {
+          reviewer: 'Entrada villa owner',
+          date: 'March 2026',
+          quote: 'Westlake properties need someone who understands the detail level involved — they did. Clean work, careful around the ornamental plantings, and they explained every recommendation before touching anything.'
+        },
+        {
+          reviewer: 'Entrada townhome resident',
+          date: 'February 2026',
+          quote: 'Standing water near our shared walkway after every rain had been a problem for two seasons. The drainage plan they put together finally moved the water where it belongs.'
+        }
+      ]}
+      considerations={[
+        {
+          title: 'Village-Format Lot Lines and Shared Structures',
+          description: 'Entrada properties sit closer together than typical Westlake estate lots, which means overspray onto neighboring walls, shared walkways, or courtyard hardscape is a real concern. Precision nozzle selection, radius adjustments, and zone separation help keep irrigation contained to planted areas only.'
+        },
+        {
+          title: 'Ornamental Plantings and Courtyard Bed Complexity',
+          description: 'The European-style landscape design in Entrada often includes mixed ornamental species, structured hedge rows, and seasonal color plantings that require different watering rates than standard turf. We calibrate zones individually so water-sensitive plantings are not overwatered alongside drought-tolerant features.'
+        },
+        {
+          title: 'Drainage in a Dense Mixed-Use Environment',
+          description: 'Entrada combines residential, commercial, and shared-use spaces on relatively tight footprints. Grading, drainage slopes, and runoff pathways need careful planning so water from irrigated beds and storm events moves away from foundations, plazas, and shared pedestrian areas effectively.'
+        },
+        {
+          title: 'Foundation-Aware Watering on Premium Structures',
+          description: 'Entrada homes and villas are premium construction with significant investment in finishes. Consistent, appropriately distributed irrigation near foundations reduces the expansion-contraction stress on underlying clay soils without introducing moisture problems against walls or slab edges.'
+        },
+        {
+          title: 'Water Conservation and Municipal Compliance',
+          description: 'Westlake homeowners are expected to follow Tarrant Regional Water District watering guidelines and any active drought stage restrictions. Smart controller programming and efficient nozzle selection keep Entrada systems compliant while maintaining the property appearance standards the community is known for.'
+        }
+      ]}
+      pricing={[
+        { label: 'Sprinkler Repair Visit', range: '$175–$475 typical scope', note: 'Most common repairs completed same visit when parts are on hand' },
+        { label: 'Smart Controller Upgrade', range: '$475–$1,100 installed', note: 'Includes setup, zone programming, and seasonal calibration' },
+        { label: 'Drainage Improvement', range: '$1,800–$8,500 based on scope', note: 'French drains, grading corrections, and courtyard runoff management' },
+        { label: 'Outdoor Lighting Service', range: '$150–$600 for diagnostics and repair', note: 'Fixture replacement, transformer checks, and zone testing' }
+      ]}
+      processSteps={[
+        'Schedule an Entrada site assessment at a time that works around your household or business schedule',
+        'Walk each irrigation zone and document pressure readings, coverage patterns, leak points, and current controller programming',
+        'Evaluate drainage low points, grading, and runoff pathways relevant to courtyard beds, shared walkways, and building foundations',
+        'Review all findings and provide repair, upgrade, or drainage recommendations with pricing before any work begins',
+        'Complete repairs with durable components and careful protection of Entrada ornamental plantings and hardscape finishes',
+        'Calibrate controller runtimes for current season and provide practical guidance for adjusting schedules through summer, fall, and drought stage changes'
+      ]}
+      faqs={[
+        {
+          question: 'Can you service sprinkler systems in Entrada in a single visit?',
+          answer: 'Most common repairs — broken heads, minor valve leaks, clogged nozzles, pressure adjustments, and controller reprogramming — can be completed in one visit when standard parts are available on the truck. More complex wiring faults, zone failures, or drainage scopes may require a follow-up assessment depending on what the initial walkthrough reveals.'
+        },
+        {
+          question: 'Do you understand the specific irrigation needs of Entrada\'s courtyard and ornamental plantings?',
+          answer: 'Yes. Village-format properties with mixed ornamental species, structured hedge rows, and seasonal color require zone-by-zone calibration rather than a one-size approach. We adjust nozzle output, arc, and radius individually to match what each planting area actually needs.'
+        },
+        {
+          question: 'How do I keep my Entrada irrigation system compliant with Tarrant Regional Water District rules?',
+          answer: 'We program smart controllers to run within the current permitted watering windows and output rates, and we can update schedules whenever drought stage restrictions change. Having a weather-based smart controller makes staying compliant much easier because it adjusts automatically based on real-time conditions.'
+        },
+        {
+          question: 'Can you address drainage near shared Entrada walkways and courtyards?',
+          answer: 'Yes. Drainage in a mixed-use, village-format neighborhood requires careful attention to grading, runoff direction, and where water ultimately needs to go. We evaluate the problem areas during a site assessment and recommend practical solutions — French drains, grading corrections, or channel redirects — that work within the property footprint without disrupting shared spaces.'
+        },
+        {
+          question: 'Do you also handle outdoor lighting for Entrada properties?',
+          answer: 'Yes. We service existing low-voltage landscape lighting systems including fixture repairs, transformer diagnostics, zone testing, and replacement of failed components. We can also design and install new lighting for entries, walkways, ornamental trees, water features, and courtyard spaces.'
+        },
+        {
+          question: 'What permits do I need before changing sprinkler or drainage systems in Westlake?',
+          answer: 'Permit requirements for irrigation and drainage work in Westlake are managed through the Town of Westlake Building Permits and Inspections office. We recommend confirming current requirements with the town before beginning any project that affects exterior utilities, grading, or drainage on your property.'
+        }
+      ]}
+      relatedAreas={[
+        {
+          name: 'Westlake Service Area',
+          description: 'Full sprinkler repair, irrigation, drainage, and lighting coverage across all Westlake neighborhoods and communities.',
+          link: '/westlake'
+        },
+        {
+          name: 'Vaquero',
+          description: 'Irrigation repair and drainage planning for estate-scale Vaquero Golf Club properties in Westlake.',
+          link: '/westlake'
+        },
+        {
+          name: 'Glenwyck Farms',
+          description: 'Sprinkler service, controller upgrades, and drainage support for Glenwyck Farms homeowners in Westlake.',
+          link: '/westlake'
+        }
+      ]}
+      popularServices={[
+        {
+          title: 'Sprinkler Repair',
+          description: 'Broken heads, leaking valves, low-pressure zones, wiring faults, and uneven coverage corrections for Entrada properties.',
+          link: '/westlake/sprinkler-repair-services-in-westlake-tx'
+        },
+        {
+          title: 'Irrigation Repair',
+          description: 'System-level diagnostics for zone control, controller performance, pressure regulation, and scheduling optimization.',
+          link: '/westlake/irrigation-repair-services-in-westlake-tx'
+        },
+        {
+          title: 'Drainage Solutions',
+          description: 'French drains, grading corrections, and runoff planning for Entrada courtyards, walkways, and building foundations.',
+          link: '/westlake/sprinkler-repair-services-in-westlake-tx'
+        },
+        {
+          title: 'Sprinkler Installation',
+          description: 'New irrigation system design and installation for Entrada villas, townhomes, and courtyard landscape areas.',
+          link: '/westlake/sprinkler-installation-services-in-westlake-tx'
+        }
+      ]}
+      attractions={[
+        {
+          name: 'Town of Westlake',
+          url: 'https://westlake-tx.org',
+          description: 'The official municipal hub for Entrada residents — municipal services, development standards, permit information, and community updates for the Town of Westlake.'
+        },
+        {
+          name: 'Westlake Academy',
+          url: 'https://westlake-tx.org/139/Westlake-Academy',
+          description: 'Westlake\'s acclaimed open-enrollment International Baccalaureate charter school serving PK–12 students, a major draw for families choosing Entrada and the surrounding Westlake community.'
+        },
+        {
+          name: 'Solana Business Park',
+          url: 'https://www.google.com/maps/place/Solana+Business+Park,+Westlake,+TX',
+          description: 'A landmark mixed-use office and commercial campus in Westlake that anchors the professional character of the area and is easily accessible from Entrada via Davis Boulevard.'
+        },
+        {
+          name: 'Vaquero Golf Club',
+          url: 'https://www.google.com/maps/place/Vaquero+Club,+Westlake,+TX',
+          description: 'A premier private golf club within Westlake known for its championship course and estate-home community, reflecting the premium residential character shared across Westlake neighborhoods.'
+        },
+        {
+          name: 'Tarrant Regional Water District',
+          url: 'https://www.trwd.com',
+          description: 'The regional water authority managing supply, conservation programs, and drought contingency guidelines that directly affect irrigation scheduling for Entrada homeowners.'
+        }
+      ]}
+      localLivingContent={
+        <>
+          <p>
+            Entrada brings a rare European-village design to Westlake, combining pedestrian-friendly streets, ornamental water features, and a walkable mix of residences and boutique commercial spaces within one of the most exclusive municipalities in North Texas. For homeowners, that distinctive setting also comes with distinctive maintenance responsibilities — irrigation systems need to perform with precision in a layout where shared walls, courtyard plantings, and structured hardscape leave little margin for overspray or coverage gaps.
+          </p>
+          <p>
+            Texas Best Sprinklers, Drainage and Lighting serves the broader{' '}
+            <a
+              href='/westlake'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              Westlake service area
+            </a>{' '}
+            with sprinkler repair, drainage planning, and outdoor lighting support calibrated for the premium property standards Westlake homeowners expect. Whether you manage a courtyard villa, a townhome with ornamental bed lines, or a larger estate-format property elsewhere in the community, our licensed irrigators understand the detail level these landscapes require.
+          </p>
+          <p>
+            When irrigation issues arise in Entrada — low pressure in a courtyard zone, a valve that runs inconsistently, standing water near a shared walkway — the right response is a methodical assessment rather than a quick patch. Our process covers each zone individually, checks controller programming against current{' '}
+            <a
+              href='https://www.trwd.com'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              Tarrant Regional Water District
+            </a>{' '}
+            guidelines, and identifies any drainage vulnerabilities before they become structural concerns.
+          </p>
+          <p>
+            Homeowners planning changes to exterior irrigation, lighting, or drainage should also review permit requirements through the{' '}
+            <a
+              href='https://westlake-tx.org/175/Building-Permits-and-Inspections'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              Town of Westlake Building Permits and Inspections
+            </a>{' '}
+            office before beginning any project. In a dense, design-forward neighborhood like Entrada, understanding what requires approval helps protect both your investment and the community's visual standards. Our team can help you think through scope, drainage implications, and what to document before a project moves forward.
+          </p>
+        </>
+      }
+      articleContent={
+        <section className='py-12 px-4'>
+          <div className='mx-auto max-w-4xl'>
+            <h2 className='text-2xl font-bold text-gray-900 mb-6'>About the Entrada Area in Westlake, TX</h2>
+            <p className='text-gray-700 mb-4'>
+              Tucked into the heart of Westlake, Entrada is a master-planned neighborhood that feels more like a European village than a typical North Texas development. Designed with pedestrian-friendly streets, intimate plazas, and a mix of residential and commercial spaces, it offers homeowners a distinctive setting while still connecting easily to the broader Dallas–Fort Worth area. The community's location near major corridors such as SH 114 and Davis Boulevard makes commuting to business centers in Southlake, Las Colinas, or downtown Fort Worth straightforward for many residents.
+            </p>
+            <p className='text-gray-700 mb-4'>
+              Entrada is part of the Town of Westlake, which gives homeowners access to a small, highly engaged municipal community and its resources. The town provides key information on local services, development standards, and municipal codes through the official{' '}
+              <a href='https://westlake-tx.org' target='_blank' rel='noopener noreferrer' className='text-emerald-700 hover:text-emerald-800 underline'>
+                Town of Westlake
+              </a>{' '}
+              website. Because Entrada is a dense, mixed-use environment with shared streetscapes, courtyards, and common greens, many properties rely on coordinated landscape design and attention to drainage to preserve both curb appeal and long-term structural health.
+            </p>
+            <p className='text-gray-700 mb-4'>
+              Families in Entrada often look closely at school options, as education is a major draw for moving to Westlake. The community is served by the highly regarded{' '}
+              <a href='https://www.southlakecarroll.edu' target='_blank' rel='noopener noreferrer' className='text-emerald-700 hover:text-emerald-800 underline'>
+                Carroll Independent School District
+              </a>
+              , and some families may also explore enrollment at Westlake Academy, the town's open-enrollment International Baccalaureate charter school, via the town's education resources on{' '}
+              <a href='https://westlake-tx.org' target='_blank' rel='noopener noreferrer' className='text-emerald-700 hover:text-emerald-800 underline'>
+                westlake-tx.org
+              </a>
+              . School-year traffic patterns around nearby campuses and along 114 can influence morning and afternoon commute times, so many residents plan their schedules around school drop-off and pickup periods.
+            </p>
+            <p className='text-gray-700 mb-4'>
+              For outdoor time beyond Entrada's own walkable promenades and water features, residents have convenient access to nearby parks, trails, and open spaces throughout the region. Westlake partners with neighboring communities on recreational offerings, and homeowners often explore area facilities through the{' '}
+              <a href='https://www.cityofkeller.com/services/parks-recreation' target='_blank' rel='noopener noreferrer' className='text-emerald-700 hover:text-emerald-800 underline'>
+                City of Keller Parks and Recreation
+              </a>{' '}
+              and{' '}
+              <a href='https://www.cityofsouthlake.com' target='_blank' rel='noopener noreferrer' className='text-emerald-700 hover:text-emerald-800 underline'>
+                City of Southlake
+              </a>{' '}
+              parks systems. These nearby parks, athletic fields, and trail networks help balance Entrada's urban village feel with opportunities for biking, jogging, and youth sports just a short drive away.
+            </p>
+            <p className='text-gray-700 mb-4'>
+              Because Westlake sits in a North Texas climate with hot summers and periodic drought, water use is an important topic for Entrada homeowners. Residents are encouraged to stay current on watering schedules, drought contingency measures, and conservation programs through the regional provider{' '}
+              <a href='https://www.trwd.com' target='_blank' rel='noopener noreferrer' className='text-emerald-700 hover:text-emerald-800 underline'>
+                Tarrant Regional Water District
+              </a>
+              . Local watering rules and any seasonal restrictions are typically coordinated with municipal guidance, so checking both town and utility resources is a normal part of managing an irrigation system or planning new landscaping.
+            </p>
+            <p className='text-gray-700 mb-4'>
+              Homeowners in Entrada also need to be mindful of permits, especially when making changes that affect the exterior appearance, utilities, or drainage of their property. The Town of Westlake provides permit, inspection, and development guidelines on its{' '}
+              <a href='https://westlake-tx.org/175/Building-Permits-and-Inspections' target='_blank' rel='noopener noreferrer' className='text-emerald-700 hover:text-emerald-800 underline'>
+                Building Permits and Inspections
+              </a>{' '}
+              page, which is a useful starting point before beginning any substantial project. In a village-style neighborhood with shared walls, tight lot lines, and structured streetscapes, thoughtful planning around grading, runoff, and sprinkler placement helps prevent issues like standing water, foundation stress, or overspray onto sidewalks and streets.
+            </p>
+            <p className='text-gray-700'>
+              Day to day, Entrada residents enjoy a lifestyle that blends the convenience of walkable restaurants and services with the privacy of well-designed homes, townhomes, and villas. Many households split time between home offices, nearby corporate campuses, and the airport, making Westlake's central location a key advantage. With a combination of distinctive architecture, strong local schools, and easy access to municipal and regional resources, Entrada offers a uniquely integrated living environment for Westlake homeowners who value both design and practicality.
+            </p>
+          </div>
+        </section>
+      }
+    />
+  );
+}

--- a/src/components/neighborhoods/EntradaPage.tsx
+++ b/src/components/neighborhoods/EntradaPage.tsx
@@ -76,10 +76,10 @@ export default function EntradaPage() {
         }
       ]}
       pricing={[
-        { label: 'Sprinkler Repair Visit', range: '$175–$475 typical scope', note: 'Most common repairs completed same visit when parts are on hand' },
-        { label: 'Smart Controller Upgrade', range: '$475–$1,100 installed', note: 'Includes setup, zone programming, and seasonal calibration' },
-        { label: 'Drainage Improvement', range: '$1,800–$8,500 based on scope', note: 'French drains, grading corrections, and courtyard runoff management' },
-        { label: 'Outdoor Lighting Service', range: '$150–$600 for diagnostics and repair', note: 'Fixture replacement, transformer checks, and zone testing' }
+        { label: 'Sprinkler Repair Visit', range: '$175–$475 typical scope' },
+        { label: 'Smart Controller Upgrade', range: '$475–$1,100 installed' },
+        { label: 'Drainage Improvement', range: '$1,800–$8,500 based on scope' },
+        { label: 'Outdoor Lighting Service', range: '$150–$600 for diagnostics and repair' }
       ]}
       processSteps={[
         'Schedule an Entrada site assessment at a time that works around your household or business schedule',

--- a/src/data/locationData.ts
+++ b/src/data/locationData.ts
@@ -236,7 +236,17 @@ export const locationData = {
     nearestOffice: 'Weatherford',
     distanceFromOffice: 31,
     landmarks: ['Solana Business Park', 'Westlake Academy', 'Vaquero Golf Club'],
-    neighborhoods: ['Vaquero', 'Granada', 'Terra Bella', 'Glenwyck Farms', 'Entrada'],
+    neighborhoods: [
+      'Vaquero',
+      'Granada',
+      'Terra Bella',
+      'Glenwyck Farms',
+      {
+        name: 'Entrada',
+        description: 'Sprinkler repair, irrigation tuning, drainage planning, and lighting support for Entrada homeowners in Westlake, TX.',
+        link: '/westlake/entrada'
+      }
+    ],
     coordinates: {
       latitude: 32.9918,
       longitude: -97.1967


### PR DESCRIPTION
## Summary
- New neighborhood page: Entrada under Westlake
- Generated by content-agent (phased workflow)
- Files committed: `src/app/westlake/entrada/page.tsx`, `src/components/neighborhoods/EntradaPage.tsx`, `src/data/locationData.ts`
## Test plan
- [ ] Page renders at `/westlake/entrada`
- [ ] Westlake city page has a clickable link to Entrada
- [ ] No placeholder tokens in rendered content