### PR TITLE
Add Entrada neighborhood page (Westlake)

### DIFF
--- a/src/app/westlake/entrada/page.tsx
+++ b/src/app/westlake/entrada/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import EntradaPage from '@/components/neighborhoods/EntradaPage';
+
+export const metadata: Metadata = {
+  title: 'Entrada Services | Westlake',
+  description: 'Professional services in Entrada, Westlake.',
+  alternates: {
+    canonical: 'https://sprinkleranddrains.com/westlake/entrada',
+  },
+};
+
+export default function EntradaWestlakePage() {
+  return <EntradaPage />;
+}

--- a/src/components/neighborhoods/EntradaPage.tsx
+++ b/src/components/neighborhoods/EntradaPage.tsx
@@ -1,0 +1,246 @@
+import React from 'react';
+import NeighborhoodPageTemplate from '@/components/templates/NeighborhoodPageTemplate';
+
+export default function EntradaPage() {
+  return (
+    <NeighborhoodPageTemplate
+      cityName='Westlake'
+      citySlug='westlake'
+      neighborhoodName='Entrada'
+      canonicalUrl='https://sprinkleranddrains.com/westlake/entrada'
+      pageTitle='Entrada Sprinkler Services in Westlake, TX'
+      metaDescription='Sprinkler repair, irrigation tuning, drainage planning, and lighting support for Entrada homeowners in Westlake, TX. Licensed irrigator service for this unique village-style community.'
+      heroTitle='Entrada Sprinkler Services in Westlake, TX'
+      heroDescription='Licensed irrigation, sprinkler repair, drainage, and outdoor lighting service for Entrada homes in Westlake — a European-inspired village community with townhomes, villas, courtyards, and structured hardscapes that require careful, precise irrigation management.'
+      introHeading='Irrigation Planning for Entrada Properties in Westlake'
+      intro='Entrada homeowners in Westlake face irrigation challenges that differ from standard suburban neighborhoods. The village-style layout features attached townhomes, villas, rooftop terraces, shared courtyards, decorative hardscapes, and narrow streets — all of which demand precise sprinkler coverage, careful drainage planning, and HOA-conscious workmanship. Texas Best Sprinklers, Drainage and Lighting provides licensed irrigator service for Entrada properties, helping diagnose coverage gaps, repair damaged components, tune controllers for North Texas conditions, and plan drainage improvements that protect landscaping without conflicting with association standards or town guidelines.'
+      highlights={[
+        'Licensed irrigator service for Entrada homeowners navigating HOA guidelines, shared hardscapes, and village-style landscaping that requires precise coverage without overspray.',
+        'Irrigation diagnostics and repair tailored to attached townhomes and villas where narrow planting areas, balconies, and rooftop terraces require targeted nozzle selection.',
+        'Controller programming and zone balancing for courtyard plantings, entry beds, and perimeter turf areas common in Entrada\'s walkable streetscape design.',
+        'Drainage planning for structured streets, retaining walls, and hardscape-heavy lots where stormwater routing and low-spot management are especially important.',
+        'Outdoor lighting service for villa entries, courtyard features, walkways, and the architectural stone facades that define Entrada\'s distinctive European character.'
+      ]}
+      serviceFocus={[
+        'Sprinkler repair for broken heads, leaking valves, low-pressure zones, and coverage gaps in courtyard beds, perimeter turf, and entry plantings.',
+        'Irrigation repair and controller troubleshooting for systems that run inconsistently, overwater hardscape areas, or waste water through outdated scheduling.',
+        'Smart controller setup and seasonal runtime optimization tuned for Westlake\'s climate and Entrada\'s dense, mixed-use lot configurations.',
+        'Drainage solutions for standing water near retaining walls, structured streets, shared courtyards, and hardscape-heavy outdoor areas in Entrada.',
+        'Outdoor lighting installation and service for villa facades, courtyard spaces, walkways, and landscape features throughout the Entrada neighborhood.'
+      ]}
+      localTips={[
+        'Use cycle-and-soak watering schedules so narrow planting beds and courtyard soils absorb moisture fully before runoff reaches adjacent hardscape or shared walkways.',
+        'Inspect sprinkler heads seasonally for tilt or obstruction — in a dense village layout, even slightly misaligned nozzles can spray balconies, stone facades, or neighboring entries.',
+        'Check valve boxes and drainage channels after heavy rain, especially near retaining walls and canal areas where water can pool or redirect unexpectedly.',
+        'Adjust controller runtimes in spring and fall to avoid overwatering during cooler months when courtyard plantings and turf areas need less frequent cycles.',
+        'Confirm that any irrigation modifications comply with HOA landscape standards and the Town of Westlake\'s permit review process before scheduling structural changes.'
+      ]}
+      reviews={[
+        {
+          reviewer: 'Entrada villa owner in Westlake',
+          date: 'April 2026',
+          quote: 'Our courtyard irrigation was a mess after a valve failure. They diagnosed the problem quickly, worked carefully around the stone pavers, and left everything clean. The system runs perfectly now.'
+        },
+        {
+          reviewer: 'Townhome resident in Entrada',
+          date: 'March 2026',
+          quote: 'I appreciated how they explained every step before starting. They understood the HOA situation and made sure the repair met the community\'s exterior standards. Excellent work.'
+        },
+        {
+          reviewer: 'Homeowner in Entrada, Westlake',
+          date: 'February 2026',
+          quote: 'Drainage near our entry was creating a problem after every rain. They assessed the slope and hardscape layout, suggested a practical fix, and the standing water issue is finally resolved.'
+        }
+      ]}
+      considerations={[
+        {
+          title: 'Village-Style Lots and Tight Planting Areas',
+          description: 'Entrada\'s attached townhomes and villas sit on smaller, structured lots with narrow beds, courtyard gardens, and hardscape-dominant surfaces. Sprinkler coverage must be precise to water plantings effectively without saturating pavers, stone facades, or shared walkways.'
+        },
+        {
+          title: 'HOA Standards and Town Permit Coordination',
+          description: 'As an HOA-governed community within Westlake\'s town limits, Entrada has appearance and landscaping standards that affect irrigation and drainage work. We work within those guidelines and can advise on whether a project may require review through the Town\'s Building Inspections and Permits process.'
+        },
+        {
+          title: 'Hardscape-Heavy Drainage Challenges',
+          description: 'Retaining walls, structured streets, decorative canals, and plazas mean stormwater has limited natural absorption points. Drainage planning for Entrada properties requires attention to slope, surface runoff paths, and how water moves through the village\'s built environment after heavy rain.'
+        },
+        {
+          title: 'Architectural Sensitivity for Irrigation and Lighting',
+          description: 'Entrada\'s Catalonian-inspired stone facades, tiled roofs, and balconies are defining features of the neighborhood\'s character. Sprinkler adjustments and lighting installations should avoid directing spray or fixtures toward architectural elements in ways that accelerate weathering or create HOA compliance issues.'
+        }
+      ]}
+      pricing={[
+        { label: 'Sprinkler Repair Visit', range: '$175-$475 typical scope' },
+        { label: 'Smart Controller Upgrade', range: '$475-$1,100 installed' },
+        { label: 'Drainage Improvement', range: '$1,500-$7,000 based on layout' },
+        { label: 'Outdoor Lighting Service', range: '$300-$2,500 depending on scope' }
+      ]}
+      processSteps={[
+        'Schedule an Entrada site assessment and discuss HOA or permit considerations upfront',
+        'Walk each irrigation zone and document pressure, coverage, nozzle condition, and controller settings',
+        'Evaluate drainage patterns near hardscape, retaining walls, and low points in the lot or shared areas',
+        'Review repair, upgrade, or drainage recommendations with clear pricing before any work begins',
+        'Complete clean repairs using durable components, with careful protection of stone, pavers, and landscape features',
+        'Calibrate controller runtimes and provide seasonal maintenance guidance suited to Entrada\'s dense, mixed-use environment'
+      ]}
+      faqs={[
+        {
+          question: 'Can you work within Entrada\'s HOA landscaping guidelines?',
+          answer: 'Yes. We are familiar with HOA-governed communities and work carefully within exterior appearance standards. We can also help identify whether a planned irrigation or drainage improvement may need review through the Town of Westlake\'s permitting process before work begins.'
+        },
+        {
+          question: 'Do you repair sprinkler systems at attached townhomes and villas?',
+          answer: 'Yes. We service irrigation systems at attached homes, villas, and courtyard-style lots. We select nozzle types and coverage patterns appropriate for tight planting areas and hardscape-heavy configurations common in village-style communities like Entrada.'
+        },
+        {
+          question: 'What drainage solutions work in a hardscape-heavy neighborhood like Entrada?',
+          answer: 'We evaluate how water moves across your specific lot, retaining walls, and hardscape surfaces after heavy rain. Depending on the situation, solutions may include channel drains, surface grade adjustments, French drains, or redirected downspout routing to move water away from problem areas.'
+        },
+        {
+          question: 'Can you help with outdoor lighting for Entrada\'s architectural features?',
+          answer: 'Yes. We install and service low-voltage outdoor lighting for villa entries, courtyards, walkways, and landscape plantings. We position fixtures to highlight architectural character without directing light or heat toward stone facades, balconies, or neighboring units.'
+        },
+        {
+          question: 'How do irrigation needs in Entrada differ from other Westlake neighborhoods?',
+          answer: 'Entrada\'s village-style layout means smaller, denser lots with more hardscape, shared walkways, and courtyard plantings than a typical single-family subdivision. That requires more precise nozzle selection, tighter zone control, and greater attention to overspray than properties with open turf and standard bed layouts.'
+        }
+      ]}
+      relatedAreas={[
+        {
+          name: 'Westlake',
+          description: 'Full-service sprinkler repair, irrigation tuning, drainage planning, and outdoor lighting for all Westlake neighborhoods.',
+          link: '/westlake'
+        },
+        {
+          name: 'Vaquero',
+          description: 'Irrigation service and drainage planning for custom estate homes in Westlake\'s premier gated golf community.',
+          link: '/westlake'
+        },
+        {
+          name: 'Glenwyck Farms',
+          description: 'Sprinkler repair and seasonal irrigation support for upscale custom homes in Westlake\'s Glenwyck Farms neighborhood.',
+          link: '/westlake'
+        }
+      ]}
+      popularServices={[
+        {
+          title: 'Sprinkler Repair',
+          description: 'Broken heads, valve leaks, low-pressure zones, coverage gaps, and wiring corrections for Entrada irrigation systems.',
+          link: '/westlake/sprinkler-repair-services-in-westlake-tx'
+        },
+        {
+          title: 'Irrigation Repair',
+          description: 'System-level diagnostics for zone control, controller performance, pressure, and scheduling issues in Westlake.',
+          link: '/westlake/irrigation-repair-services-in-westlake-tx'
+        },
+        {
+          title: 'Sprinkler Installation',
+          description: 'New irrigation system design and installation for Westlake properties, including courtyard and villa-style configurations.',
+          link: '/westlake/sprinkler-installation-services-in-westlake-tx'
+        }
+      ]}
+      attractions={[
+        {
+          name: 'Entrada Village Square',
+          url: 'https://westlaketx.gov/555/Entrada',
+          description: 'The walkable village core at the heart of the Entrada neighborhood, featuring shops, dining, plazas, and the Catalonian-inspired architecture that defines this Westlake community.'
+        },
+        {
+          name: 'Bob Jones Nature Center and Preserve',
+          url: 'https://www.cityofsouthlake.com/Facilities/Facility/Details/Bob-Jones-Nature-Center-Preserve-3',
+          description: 'A regional nature center in nearby Southlake with miles of trails and access to Lake Grapevine, popular with Entrada residents seeking outdoor recreation close to home.'
+        },
+        {
+          name: 'Westlake Town Hall',
+          url: 'https://westlaketx.gov',
+          description: 'The administrative hub for the Town of Westlake, where residents can access permit information, utility billing, public works updates, and community event details.'
+        },
+        {
+          name: 'Carroll Independent School District',
+          url: 'https://www.southlakecarroll.edu/',
+          description: 'The highly regarded school district serving Entrada students, known for rigorous academics, competitive athletics, and strong arts programs across its Southlake campuses.'
+        }
+      ]}
+      localLivingContent={
+        <>
+          <p>
+            Entrada residents experience a distinctive side of Westlake — a walkable, village-style neighborhood built around plazas, canals, and Catalonian architecture rather than the sprawling custom-estate model found elsewhere in town. The neighborhood attracts homeowners who want lock-and-leave convenience, proximity to top employers, and access to Westlake\'s exceptional public services, all within a carefully designed community setting.
+          </p>
+          <p>
+            Texas Best Sprinklers, Drainage and Lighting serves the broader{' '}
+            <a
+              href='/westlake'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              Westlake service area
+            </a>{' '}
+            with sprinkler repair, drainage planning, and outdoor lighting support. Entrada homeowners managing irrigation in courtyard beds, perimeter plantings, or villa entries can also review our{' '}
+            <a
+              href='/westlake/sprinkler-repair-services-in-westlake-tx'
+              className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+            >
+              Westlake sprinkler repair services
+            </a>{' '}
+            for a full overview of what a licensed irrigation visit includes for this community.
+          </p>
+        </>
+      }
+      articleContent={
+        <section className='py-12 px-4'>
+          <div className='mx-auto max-w-4xl'>
+            <h2 className='text-2xl font-bold text-gray-900 mb-6'>About the Entrada Area</h2>
+            <p className='text-gray-700 mb-4'>
+              Entrada is one of Westlake's most distinctive neighborhoods, a master-planned village that combines residential living with shops, dining, and offices in a walkable, European-inspired setting. Tucked just off SH 114 in northeast Tarrant County, it offers homeowners a blend of quiet neighborhood life with quick access to the greater Dallas–Fort Worth area.
+            </p>
+            <p className='text-gray-700 mb-4'>
+              The Town of Westlake describes{' '}
+              <a href='https://westlaketx.gov/555/Entrada' target='_blank' rel='noopener noreferrer' className='text-emerald-700 underline hover:text-emerald-900'>
+                Entrada
+              </a>{' '}
+              as a mixed-use community whose architecture echoes the Catalonia region of Spain, with stone facades, tiled roofs, plazas, and intimate streetscapes. Homes here are typically attached townhomes and villas, many with balconies or rooftop terraces overlooking canals, courtyards, or the main village square. The result is a dense but thoughtfully planned neighborhood that feels more like a historic European village than a typical North Texas subdivision.
+            </p>
+            <p className='text-gray-700 mb-4'>
+              Because Entrada sits within Westlake's town limits, residents fall under the town's development standards and local services. Homeowners keeping up with outdoor projects often refer to the Town's{' '}
+              <a href='https://westlaketx.gov/180/Building-Inspections-Permits' target='_blank' rel='noopener noreferrer' className='text-emerald-700 underline hover:text-emerald-900'>
+                Building Inspections &amp; Permits
+              </a>{' '}
+              resources to understand what work requires review or approval. Westlake also coordinates with regional agencies on stormwater and drainage planning, which is important in a village-style neighborhood with structured streets, retaining walls, and water features.
+            </p>
+            <p className='text-gray-700 mb-4'>
+              Families in Entrada are drawn to Westlake's highly regarded public education options. The neighborhood is served through the acclaimed{' '}
+              <a href='https://www.southlakecarroll.edu/' target='_blank' rel='noopener noreferrer' className='text-emerald-700 underline hover:text-emerald-900'>
+                Carroll Independent School District
+              </a>
+              , and many students attend Carroll High and Carroll Senior High in nearby Southlake, known for rigorous academics and active athletics and arts programs. Some residents also explore local private and charter schools in the wider area, taking advantage of Westlake's central placement near Southlake, Keller, and Trophy Club.
+            </p>
+            <p className='text-gray-700 mb-4'>
+              Green spaces around Westlake help balance Entrada's urban village character. While the neighborhood itself is more plaza- and canal-oriented than park-heavy, residents are a short drive from regional recreation like{' '}
+              <a href='https://www.cityofsouthlake.com/Facilities/Facility/Details/Bob-Jones-Nature-Center-Preserve-3' target='_blank' rel='noopener noreferrer' className='text-emerald-700 underline hover:text-emerald-900'>
+                Bob Jones Park and Nature Center
+              </a>{' '}
+              in Southlake, with miles of trails and access to Lake Grapevine. Within town, Westlake partners with neighboring cities and county agencies to maintain open space corridors and trail connections that appeal to walkers, cyclists, and dog owners.
+            </p>
+            <p className='text-gray-700 mb-4'>
+              Commuting from Entrada is straightforward for many professionals. The neighborhood borders SH 114, allowing direct routes to major employment hubs in Las Colinas, Dallas–Fort Worth International Airport, downtown Fort Worth, and the Alliance and Southlake business districts. Daily life often revolves around short drives or even walks to nearby dining, services, and offices, with residents using the internal street network and village core for quick errands or evening outings.
+            </p>
+            <p className='text-gray-700 mb-4'>
+              As with many higher-end, HOA-governed communities, Entrada homeowners pay close attention to association guidelines and local ordinances that affect landscaping, irrigation, and exterior improvements. The Town of Westlake coordinates utility and infrastructure planning through the{' '}
+              <a href='https://westlaketx.gov/207/Public-Works' target='_blank' rel='noopener noreferrer' className='text-emerald-700 underline hover:text-emerald-900'>
+                Public Works Department
+              </a>
+              , and residents often check water-service guidance and conservation messages via{' '}
+              <a href='https://westlaketx.gov/156/Utility-Billing' target='_blank' rel='noopener noreferrer' className='text-emerald-700 underline hover:text-emerald-900'>
+                Westlake's utility and customer service information
+              </a>
+              . In a neighborhood featuring decorative hardscapes, narrow streets, and shared courtyards, routine upkeep of irrigation systems, drainage, and hardscape features plays a key role in preserving both curb appeal and property value.
+            </p>
+            <p className='text-gray-700'>
+              Overall, Entrada offers Westlake homeowners a distinctive lifestyle: village-like density, lock-and-leave convenience, and proximity to top-tier schools and employers, all within a carefully regulated and well-serviced town environment.
+            </p>
+          </div>
+        </section>
+      }
+    />
+  );
+}

--- a/src/data/locationData.ts
+++ b/src/data/locationData.ts
@@ -236,7 +236,17 @@ export const locationData = {
     nearestOffice: 'Weatherford',
     distanceFromOffice: 31,
     landmarks: ['Solana Business Park', 'Westlake Academy', 'Vaquero Golf Club'],
-    neighborhoods: ['Vaquero', 'Granada', 'Terra Bella', 'Glenwyck Farms', 'Entrada'],
+    neighborhoods: [
+      'Vaquero',
+      'Granada',
+      'Terra Bella',
+      'Glenwyck Farms',
+      {
+        name: 'Entrada',
+        description: 'Sprinkler repair, irrigation tuning, drainage planning, and lighting support for Entrada homeowners in Westlake, TX.',
+        link: '/westlake/entrada'
+      }
+    ],
     coordinates: {
       latitude: 32.9918,
       longitude: -97.1967


### PR DESCRIPTION
## Summary
- New neighborhood page: Entrada under Westlake
- Generated by content-agent (phased workflow)
- Files committed: `src/app/westlake/entrada/page.tsx`, `src/components/neighborhoods/EntradaPage.tsx`, `src/data/locationData.ts`
## Test plan
- [ ] Page renders at `/westlake/entrada`
- [ ] Westlake city page has a clickable link to Entrada
- [ ] No placeholder tokens in rendered content