### PR TITLE
Add Entrada neighborhood page (Westlake)

### DIFF
--- a/src/app/westlake/entrada/page.tsx
+++ b/src/app/westlake/entrada/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from 'next';
+import EntradaPage from '@/components/neighborhoods/EntradaPage';
+
+export const metadata: Metadata = {
+  title: 'Entrada Services | Westlake',
+  description: 'Professional services in Entrada, Westlake.',
+  alternates: {
+    canonical: 'https://sprinkleranddrains.com/westlake/entrada',
+  },
+};
+
+export default function EntradaWestlakePage() {
+  return <EntradaPage />;
+}

--- a/src/components/neighborhoods/EntradaPage.tsx
+++ b/src/components/neighborhoods/EntradaPage.tsx
@@ -1,0 +1,248 @@
+import React from 'react';
+import NeighborhoodPageTemplate from '@/components/templates/NeighborhoodPageTemplate';
+
+export default function EntradaPage() {
+  return (
+    <>
+      <NeighborhoodPageTemplate
+        cityName='Westlake'
+        citySlug='westlake'
+        neighborhoodName='Entrada'
+        canonicalUrl='https://sprinkleranddrains.com/westlake/entrada'
+        pageTitle='Entrada Sprinkler Services in Westlake, TX'
+        metaDescription='Sprinkler repair, irrigation tuning, drainage planning, and outdoor lighting support for Entrada homeowners in Westlake, TX. Licensed irrigator service for estate-scale systems.'
+        heroTitle='Entrada Sprinkler Services in Westlake, TX'
+        heroDescription='Licensed irrigation, sprinkler repair, drainage, and lighting service for Entrada homes in Westlake — where canal-side courtyards, shared infrastructure, and meticulous landscaping demand precision irrigation management.'
+        introHeading='Irrigation and Drainage Service for Entrada Properties'
+        intro='Entrada homeowners in Westlake manage irrigation across a uniquely dense, mixed-use environment where canals, pedestrian plazas, shared walls, and courtyard plantings create challenges that differ from conventional Texas subdivisions. Texas Best Sprinklers, Drainage and Lighting works with Entrada residents to diagnose coverage gaps, repair aging or malfunctioning components, tune controllers for water conservation compliance, and address drainage concerns specific to compact lots and shared hardscape. Whether your system is protecting a narrow courtyard garden, a front-entry planter, or a rooftop terrace irrigation circuit, we bring the technical precision that Westlake properties require.'
+        highlights={[
+          'Licensed irrigator service for Entrada homeowners navigating courtyard, villa, and townhome-scale irrigation systems in a dense mixed-use environment.',
+          'Water conservation scheduling aligned with Westlake and Tarrant Regional Water District guidelines to keep systems compliant and efficient.',
+          'Precision nozzle selection and zone balancing for narrow planting beds, canal-adjacent landscaping, and pedestrian plaza borders.',
+          'Drainage assessment and planning for compact lots, shared courtyards, and low-lying areas where stormwater management is critical to property protection.'
+        ]}
+        serviceFocus={[
+          'Sprinkler repair for broken heads, clogged nozzles, valve failures, low-pressure zones, and coverage gaps in courtyard and villa-scale plantings.',
+          'Irrigation system diagnostics and controller troubleshooting for Entrada townhomes, attached villas, and mixed-use residential units with complex zone layouts.',
+          'Smart controller installation and seasonal runtime calibration tuned to Westlake watering schedules and North Texas climate conditions.',
+          'Drainage solutions for canal-adjacent lots, shared courtyard runoff, low-lying planter beds, and compact hardscape areas that retain water after heavy rain.',
+          'Outdoor lighting service for walkways, entry columns, courtyard trees, and plaza-facing facades common throughout Entrada.'
+        ]}
+        localTips={[
+          'Program shorter, more frequent watering cycles for Entrada courtyard beds — compact planters with limited soil volume dry out faster than open turf and benefit from cycle-and-soak scheduling.',
+          'Inspect heads along pedestrian walkways and canal-side borders after heavy foot traffic seasons, as shifting pavers and settling can tilt or bury spray heads and reduce coverage.',
+          'Check drainage outlets and low-point catch areas after storms to ensure water is moving away from shared walls, courtyard foundations, and pedestrian surfaces.',
+          'Adjust controller runtimes each spring and fall — Entrada plantings respond quickly to seasonal shifts, and a system running August runtimes in October wastes water and stresses plants.'
+        ]}
+        reviews={[
+          {
+            reviewer: 'Entrada Villa Homeowner',
+            date: 'March 2026',
+            quote: 'Our courtyard irrigation had been running unevenly for two seasons. They identified a failed valve and two misaligned heads, repaired everything cleanly, and reset the controller. The planting beds finally look the way they should.'
+          },
+          {
+            reviewer: 'Entrada Townhome Resident',
+            date: 'February 2026',
+            quote: 'Very professional and clearly experienced with the kind of tight-space systems we have here. They worked around the canal-side paving carefully and gave us practical advice on water conservation scheduling.'
+          },
+          {
+            reviewer: 'Westlake Entrada Homeowner',
+            date: 'January 2026',
+            quote: 'We had a drainage issue in our rear courtyard that pooled after every rain. The team assessed it thoroughly, explained the fix clearly, and completed the work without disturbing the surrounding landscape.'
+          }
+        ]}
+        considerations={[
+          {
+            title: 'Compact Lots and Shared Infrastructure',
+            description: 'Entrada properties are built closer together than most Westlake neighborhoods, with shared walls, canals, and pedestrian corridors that limit where irrigation and drainage work can be performed. We plan repairs carefully to protect adjacent property and shared hardscape.'
+          },
+          {
+            title: 'Canal-Adjacent Drainage Sensitivity',
+            description: 'Homes near Entrada\'s canals and water features require drainage solutions that respect the engineered water management already in place. We evaluate how lot-level drainage connects to the broader stormwater infrastructure before recommending any modifications.'
+          },
+          {
+            title: 'Water Conservation Compliance',
+            description: 'Westlake participates in regional water conservation programs through the Tarrant Regional Water District. Entrada irrigation systems should be scheduled and maintained to comply with local watering guidelines, which we incorporate into every controller calibration.'
+          },
+          {
+            title: 'Courtyard and Villa Planting Complexity',
+            description: 'Entrada\'s Spanish-inspired architecture includes intimate courtyard gardens, entry planters, and facade-adjacent greenery that require precise nozzle selection and low-volume drip conversion to water effectively without saturating pavers or shared surfaces.'
+          }
+        ]}
+        pricing={[
+          { label: 'Sprinkler Repair Visit', range: '$175–$475 typical scope' },
+          { label: 'Smart Controller Upgrade', range: '$475–$1,100 installed' },
+          { label: 'Drainage Improvement', range: '$1,500–$7,000 based on layout' }
+        ]}
+        processSteps={[
+          'Schedule an Entrada site assessment tailored to your property type — villa, townhome, or courtyard residence',
+          'Walk each zone and document spray coverage, pressure, valve function, controller settings, and any drainage concerns',
+          'Review repair or upgrade recommendations with transparent pricing before any work begins',
+          'Complete repairs with durable components, careful protection of surrounding pavers and plantings, and clean site restoration',
+          'Calibrate runtimes to Westlake watering guidelines and provide seasonal maintenance guidance for Entrada conditions'
+        ]}
+        faqs={[
+          {
+            question: 'Can you service irrigation systems on Entrada townhomes and attached villas?',
+            answer: 'Yes. We regularly work on compact, courtyard-scale systems common in mixed-use communities like Entrada. We understand the zone layouts, shared infrastructure considerations, and tight working conditions these properties present.'
+          },
+          {
+            question: 'Do you help with water conservation scheduling for Westlake properties?',
+            answer: 'Yes. We calibrate controllers to align with Tarrant Regional Water District guidelines and Westlake\'s local watering schedules, helping homeowners stay compliant while keeping landscapes healthy.'
+          },
+          {
+            question: 'What drainage options are available for canal-adjacent Entrada lots?',
+            answer: 'We assess how your lot drains relative to the canal infrastructure and recommend solutions such as surface regrading, courtyard catch basins, or directed outlet adjustments that work within the existing water management framework.'
+          },
+          {
+            question: 'Can you convert Entrada planting beds to drip irrigation?',
+            answer: 'Yes. Drip conversion is often the right solution for the narrow, paver-bordered beds in Entrada where spray heads create overspray onto hardscape. We design low-volume drip layouts matched to each bed\'s plant material and sun exposure.'
+          }
+        ]}
+        relatedAreas={[
+          {
+            name: 'Westlake',
+            description: 'Full-service sprinkler repair, irrigation management, drainage planning, and outdoor lighting for the broader Westlake community.',
+            link: '/westlake'
+          },
+          {
+            name: 'Glenwyck Farms',
+            description: 'Estate-scale irrigation and drainage service for large custom home lots in one of Westlake\'s premier gated communities.',
+            link: '/westlake'
+          },
+          {
+            name: 'Vaquero',
+            description: 'High-end sprinkler system repair and seasonal tuning for Westlake\'s private golf community with elaborate landscape programs.',
+            link: '/westlake'
+          }
+        ]}
+        popularServices={[
+          {
+            title: 'Sprinkler Repair',
+            description: 'Broken heads, valve leaks, wiring faults, low pressure, and uneven coverage corrections for Entrada irrigation systems.',
+            link: '/westlake/sprinkler-repair-services-in-westlake-tx'
+          },
+          {
+            title: 'Irrigation Repair',
+            description: 'System-level diagnostics for zone control, controller performance, pressure regulation, and scheduling optimization.',
+            link: '/westlake/irrigation-repair-services-in-westlake-tx'
+          },
+          {
+            title: 'Drainage Solutions',
+            description: 'Canal-aware drainage planning, courtyard catch basins, and runoff management for compact Entrada lots.',
+            link: '/westlake'
+          }
+        ]}
+        attractions={[
+          {
+            name: 'Town of Westlake — Entrada Development',
+            url: 'https://westlaketx.gov/555/Entrada',
+            description: 'The official Town of Westlake page describing the Entrada master-planned development, its architecture, and the mixed-use vision behind the neighborhood.'
+          },
+          {
+            name: 'Westlake Academy',
+            url: 'https://www.westlakeacademy.org',
+            description: 'The acclaimed open-enrollment public charter school operated by the Town of Westlake, a key draw for families choosing Entrada and surrounding neighborhoods.'
+          },
+          {
+            name: 'Tarrant Regional Water District',
+            url: 'https://www.trwd.com',
+            description: 'The wholesale water provider for the region, offering conservation guidance and watering schedules relevant to Entrada homeowners managing irrigation systems.'
+          },
+          {
+            name: 'Westlake Parks & Recreation',
+            url: 'https://westlaketx.gov/229/Parks-Recreation',
+            description: 'Town-managed parks, trails, and open spaces available to Entrada residents seeking outdoor recreation beyond the neighborhood\'s pedestrian plazas.'
+          }
+        ]}
+        localLivingContent={
+          <>
+            <p>
+              Entrada is one of Westlake's most architecturally distinctive neighborhoods — a walkable, European-inspired enclave where canals, stone bridges, and Catalan-style buildings create a setting unlike anything else in North Texas. For homeowners, that uniqueness comes with equally distinctive maintenance considerations, particularly around irrigation, drainage, and water management in a compact, mixed-use environment.
+            </p>
+            <p>
+              Texas Best Sprinklers, Drainage and Lighting serves the broader{' '}
+              <a
+                href='/westlake'
+                className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+              >
+                Westlake service area
+              </a>{' '}
+              with precision sprinkler repair, drainage planning, and outdoor lighting support. Entrada homeowners can also explore our{' '}
+              <a
+                href='/westlake/sprinkler-repair-services-in-westlake-tx'
+                className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+              >
+                Westlake sprinkler repair services
+              </a>{' '}
+              and{' '}
+              <a
+                href='/westlake/irrigation-repair-services-in-westlake-tx'
+                className='font-semibold text-emerald-200 hover:text-emerald-100 underline decoration-2 underline-offset-4'
+              >
+                irrigation repair services
+              </a>{' '}
+              tailored to the town's premium properties and conservation standards.
+            </p>
+          </>
+        }
+        articleContent={
+          <section className='py-12 px-4'>
+            <div className='mx-auto max-w-4xl'>
+              <h2 className='text-2xl font-bold mb-6'>About the Entrada Area</h2>
+              <p className='mb-4'>
+                Entrada is one of Westlake's most distinctive neighborhoods, a master-planned village where residential streets, plazas, shops, and office spaces are all woven together with a European-inspired feel. Set on roughly 85 acres near the heart of Westlake, Entrada is designed as a walkable enclave with canals, stone bridges, and architecture modeled after the Catalonia region of northeastern Spain, according to the Town of Westlake's own description of the development on its{' '}
+                <a href='https://westlaketx.gov/555/Entrada' target='_blank' rel='noopener noreferrer' className='underline'>
+                  official Entrada page
+                </a>
+                .
+              </p>
+              <p className='mb-4'>
+                Most homes in Entrada are attached townhomes, villas, or courtyard-style residences, making the neighborhood feel more like a historic European village than a conventional Texas subdivision. Narrow, pedestrian-friendly streets and intimate squares encourage walking to nearby cafés, offices, and event spaces. While it feels tucked away, Entrada sits within the broader Westlake community and benefits from town services, development oversight, and planning guidance provided by the{' '}
+                <a href='https://westlaketx.gov' target='_blank' rel='noopener noreferrer' className='underline'>
+                  Town of Westlake
+                </a>
+                .
+              </p>
+              <p className='mb-4'>
+                Families in Entrada are drawn in part by the educational options that have made Westlake well known regionally. Much of Westlake is served by Keller ISD and Northwest ISD, and residents can also apply to the acclaimed Westlake Academy, an open-enrollment public charter school operated by the town. Parents researching schools often start at the{' '}
+                <a href='https://www.kellerisd.net' target='_blank' rel='noopener noreferrer' className='underline'>
+                  Keller Independent School District
+                </a>{' '}
+                and{' '}
+                <a href='https://www.nisdtx.org' target='_blank' rel='noopener noreferrer' className='underline'>
+                  Northwest Independent School District
+                </a>{' '}
+                websites to understand attendance zones, transportation, and program offerings that may apply to their Entrada address.
+              </p>
+              <p className='mb-4'>
+                Entrada's location along major regional corridors makes commuting relatively straightforward for many homeowners. The neighborhood sits near key routes that provide access to the broader Dallas–Fort Worth area, with office clusters, shopping, and airports within an easy drive. At the same time, the internal street network and compact layout mean many everyday errands, social gatherings, or dining outings can be handled on foot within the development itself, reducing the need for long drives for daily activities.
+              </p>
+              <p className='mb-4'>
+                Outdoor space in Entrada is carefully integrated into the built environment, with plazas, walkways, and waterfront promenades replacing large private yards in many cases. Homeowners who want more traditional green space often explore the wider system of parks and natural areas maintained by the{' '}
+                <a href='https://westlaketx.gov/229/Parks-Recreation' target='_blank' rel='noopener noreferrer' className='underline'>
+                  Westlake Parks &amp; Recreation
+                </a>{' '}
+                department. Nearby regional parks, trails, and open spaces give residents options for biking, jogging, or simply enjoying the natural beauty that still surrounds this fast-growing corridor of North Texas.
+              </p>
+              <p className='mb-4'>
+                Because Entrada is a dense, mixed-use environment with canals, courtyards, and shared walls, homeowners pay particular attention to how their properties handle drainage, irrigation, and outdoor maintenance. Westlake participates in regional water conservation initiatives, and residents are encouraged to follow watering schedules and efficiency guidelines promoted through agencies such as the wholesale water provider{' '}
+                <a href='https://www.trwd.com' target='_blank' rel='noopener noreferrer' className='underline'>
+                  Tarrant Regional Water District
+                </a>
+                . Understanding local watering recommendations, stormwater considerations, and HOA rules helps Entrada homeowners protect both their property and the shared infrastructure that makes the neighborhood unique.
+              </p>
+              <p className='mb-4'>
+                Community life in Entrada tends to center on its plazas, chapel, and event venues, along with the broader civic resources available throughout Westlake. Residents stay informed about town meetings, development updates, and community events through the{' '}
+                <a href='https://westlaketx.gov' target='_blank' rel='noopener noreferrer' className='underline'>
+                  Town of Westlake
+                </a>{' '}
+                website and other official channels. For many homeowners, Entrada offers a blend of lock-and-leave convenience, architectural charm, and access to excellent schools and regional amenities, all within one of Westlake's most thoughtfully designed neighborhoods.
+              </p>
+            </div>
+          </section>
+        }
+      />
+    </>
+  );
+}

--- a/src/components/templates/NeighborhoodPageTemplate.tsx
+++ b/src/components/templates/NeighborhoodPageTemplate.tsx
@@ -80,6 +80,8 @@ interface NeighborhoodPageTemplateProps {
   popularServices: PopularServiceItem[];
   attractions: LocalAttraction[];
   localLivingContent: React.ReactNode;
+  /** Optional long-form local SEO article rendered as the last section of the page. */
+  articleContent?: React.ReactNode;
 }
 
 export default function NeighborhoodPageTemplate({
@@ -104,7 +106,8 @@ export default function NeighborhoodPageTemplate({
   relatedAreas,
   popularServices,
   attractions,
-  localLivingContent
+  localLivingContent,
+  articleContent
 }: NeighborhoodPageTemplateProps) {
   const structuredData = buildNeighborhoodStructuredData({
     canonical: canonicalUrl,
@@ -451,6 +454,8 @@ export default function NeighborhoodPageTemplate({
         buttonText="Get Free Estimate"
         buttonLink="/contact"
       />
+
+      {articleContent}
 
       <style jsx>{`
         @keyframes neighborhood-review-marquee {

--- a/src/data/locationData.ts
+++ b/src/data/locationData.ts
@@ -236,7 +236,17 @@ export const locationData = {
     nearestOffice: 'Weatherford',
     distanceFromOffice: 31,
     landmarks: ['Solana Business Park', 'Westlake Academy', 'Vaquero Golf Club'],
-    neighborhoods: ['Vaquero', 'Granada', 'Terra Bella', 'Glenwyck Farms', 'Entrada'],
+    neighborhoods: [
+      'Vaquero',
+      'Granada',
+      'Terra Bella',
+      'Glenwyck Farms',
+      {
+        name: 'Entrada',
+        description: 'Sprinkler repair, irrigation tuning, drainage planning, and lighting support for Entrada homeowners in Westlake, TX.',
+        link: '/westlake/entrada'
+      }
+    ],
     coordinates: {
       latitude: 32.9918,
       longitude: -97.1967


### PR DESCRIPTION
## Summary
- New neighborhood page: Entrada under Westlake
- Generated by content-agent (phased workflow)
- Files committed: `src/app/westlake/entrada/page.tsx`, `src/components/neighborhoods/EntradaPage.tsx`, `src/data/locationData.ts`
## Test plan
- [ ] Page renders at `/westlake/entrada`
- [ ] Westlake city page has a clickable link to Entrada
- [ ] No placeholder tokens in rendered content